### PR TITLE
Fix database creation issue by adding db:create to Railway deployment

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0 -p $PORT"
+    "startCommand": "bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0 -p $PORT"
   }
 }


### PR DESCRIPTION
- Add rails db:create before db:migrate in railway.json
- Ensures database exists before running migrations
- Fixes 'database railway not found' error in production console