### PR TITLE
Fix PORT environment variable expansion in Railway deployment

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0 -p $PORT"
+    "startCommand": "sh -c 'bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0 -p $PORT'"
   }
 }


### PR DESCRIPTION
- Wrap startCommand in 'sh -c' to ensure proper  expansion
- Fixes server binding issue that was causing immediate crashes
- Should resolve 502 Bad Gateway errors after container startup