### PR TITLE
refactor: extract transaction listing logic into service and fix filt…

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,7 +1,7 @@
 class TransactionsController < ApplicationController
   def index
     # Use the Transactions::Lister service to handle filtering and sorting
-    result = Transactions::Lister.call(current_user, filter_params)
+    result = Transactions::Lister.call(current_user, request_params)
 
     if result.success?
       load_transaction_data(result.payload)
@@ -42,7 +42,7 @@ class TransactionsController < ApplicationController
 
   private
 
-  def filter_params
+  def request_params
     params.permit(:bank_account_id, :statement_file_id, :transaction_type, :from_date, :to_date, :sort, :direction)
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,85 +1,15 @@
 class TransactionsController < ApplicationController
   def index
-    scope = current_user.transactions.includes(:bank_account, :statement_file, :category)
+    # Use the Transactions::Lister service to handle filtering and sorting
+    result = Transactions::Lister.call(current_user, filter_params)
 
-    # Apply bank account filter if present
-    scope = scope.where(bank_account_id: params[:bank_account_id]) if params[:bank_account_id].present?
-
-    # Apply statement file filter if present
-    if params[:statement_file_id].present?
-      scope = scope.where(statement_file_id: params[:statement_file_id])
-      @statement_file = current_user.statement_files.find(params[:statement_file_id])
-
-      # Automatically include bank account filter when statement file is selected
-      unless params[:bank_account_id].present?
-        params[:bank_account_id] = @statement_file.bank_account_id
-        scope = scope.where(bank_account_id: @statement_file.bank_account_id)
-      end
-    end
-
-    # Apply transaction type filter if present
-    scope = scope.where(transaction_type: params[:transaction_type]) if params[:transaction_type].present?
-
-    # Apply date range filter if present
-    if params[:from_date].present? || params[:to_date].present?
-      scope = scope.date_range(params[:from_date], params[:to_date])
-    end
-
-    # Apply sorting
-    scope = apply_sorting(scope)
-
-    # Store filtered scope for stats calculations
-    @filtered_transactions = scope
-
-    # Reset to first page when filters change (only for non-AJAX requests)
-    # Sorting changes should preserve pagination and filters
-    # Simple approach: check if this is a fresh filter request
-    page = if !request.xhr? && fresh_filter_request?
-      1  # Reset to page 1 when filters change on initial page load
+    if result.success?
+      load_transaction_data(result.payload)
+      handle_pagination
+      load_dropdown_data
+      handle_ajax_request
     else
-      # Ensure page is a valid integer, default to 1 if invalid
-      begin
-        page_num = Integer(params[:page]) if params[:page].present?
-        page_num || 1
-      rescue ArgumentError
-        1
-      end
-    end
-
-    # Use Pagy for pagination with error handling
-    begin
-      @pagy, @transactions = pagy(scope, items: 20, page: page)
-    rescue Pagy::OverflowError
-      # If page is beyond total pages, reset to page 1
-      @pagy, @transactions = pagy(scope, items: 20, page: 1)
-    end
-    @bank_accounts = current_user.bank_accounts.joins(:bank).order("banks.name", :account_number)
-
-    # Load statement files for dropdown - filter by bank account if one is selected
-    if params[:bank_account_id].present?
-      @statement_files = current_user.statement_files
-                                   .joins(:bank_account)
-                                   .where(bank_account_id: params[:bank_account_id])
-                                   .order(created_at: :desc)
-    else
-      @statement_files = current_user.statement_files
-                                   .joins(:bank_account)
-                                   .order(created_at: :desc)
-    end
-
-    # Store current sort parameters for view
-    @current_sort = params[:sort] || "date"
-    @current_direction = params[:direction] || "desc"
-
-    # Handle AJAX requests for infinite scrolling
-    if request.xhr? && params[:page].present?
-      page_offset = (@pagy.page - 1) * 20
-
-      # Return HTML partial for infinite scrolling
-      render partial: "transactions/transaction_rows", locals: {
-        transactions: @transactions,
-        page_offset: page_offset
-      }
+      redirect_to transactions_path, alert: "Failed to load transactions"
     end
   end
 
@@ -112,6 +42,71 @@ class TransactionsController < ApplicationController
 
   private
 
+  def filter_params
+    params.permit(:bank_account_id, :statement_file_id, :transaction_type, :from_date, :to_date, :sort, :direction)
+  end
+
+  def load_transaction_data(payload)
+    @transactions = payload[:transactions]
+    @filtered_transactions = payload[:filtered_transactions]
+    @statement_file = payload[:statement_file]
+    @current_sort = payload[:current_sort]
+    @current_direction = payload[:current_direction]
+  end
+
+  def handle_pagination
+    # Reset to first page when filters change (only for non-AJAX requests)
+    # Sorting changes should preserve pagination and filters
+    page = if !request.xhr? && fresh_filter_request?
+      1  # Reset to page 1 when filters change on initial page load
+    else
+      # Ensure page is a valid integer, default to 1 if invalid
+      begin
+        page_num = Integer(params[:page]) if params[:page].present?
+        page_num || 1
+      rescue ArgumentError
+        1
+      end
+    end
+
+    # Use Pagy for pagination with error handling
+    begin
+      @pagy, @transactions = pagy(@transactions, items: 20, page: page)
+    rescue Pagy::OverflowError
+      # If page is beyond total pages, reset to page 1
+      @pagy, @transactions = pagy(@transactions, items: 20, page: 1)
+    end
+  end
+
+  def load_dropdown_data
+    @bank_accounts = current_user.bank_accounts.joins(:bank).order("banks.name", :account_number)
+
+    # Load statement files for dropdown - filter by bank account if one is selected
+    if params[:bank_account_id].present?
+      @statement_files = current_user.statement_files
+                                   .joins(:bank_account)
+                                   .where(bank_account_id: params[:bank_account_id])
+                                   .order(created_at: :desc)
+    else
+      @statement_files = current_user.statement_files
+                                   .joins(:bank_account)
+                                   .order(created_at: :desc)
+    end
+  end
+
+  def handle_ajax_request
+    # Handle AJAX requests for infinite scrolling
+    if request.xhr? && params[:page].present?
+      page_offset = (@pagy.page - 1) * 20
+
+      # Return HTML partial for infinite scrolling
+      render partial: "transactions/transaction_rows", locals: {
+        transactions: @transactions,
+        page_offset: page_offset
+      }
+    end
+  end
+
   def fresh_filter_request?
     # Much simpler approach: just check if filter parameters have changed
     # We'll store the current filter state in the session and compare it
@@ -136,29 +131,5 @@ class TransactionsController < ApplicationController
 
     # Return true if filters changed (requiring pagination reset)
     filters_changed
-  end
-
-  def apply_sorting(scope)
-    sort_field = params[:sort] || "date"
-    direction = params[:direction] || "desc"
-
-    case sort_field
-    when "date"
-      scope.order(date: direction.to_sym)
-    when "amount"
-      scope.order(amount: direction.to_sym)
-    when "description"
-      scope.order(description: direction.to_sym)
-    when "transaction_type"
-      scope.order(transaction_type: direction.to_sym)
-    when "category"
-      scope.joins(:category).order('categories.name': direction.to_sym)
-    when "merchant"
-      scope.order(merchant: direction.to_sym)
-    when "bank_account"
-      scope.joins(bank_account: :bank).order('banks.name': direction.to_sym)
-    else
-      scope.order(date: :desc) # Default fallback
-    end
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,6 +1,7 @@
 # app/models/transaction.rb
 class Transaction < ApplicationRecord
   include Filterable
+  include Sortable
 
   belongs_to :user
   belongs_to :bank_account
@@ -52,6 +53,15 @@ class Transaction < ApplicationRecord
   scope :filter_by_from_date, ->(from_date) { where("date >= ?", from_date) }
   scope :filter_by_to_date, ->(to_date) { where("date <= ?", to_date) }
   scope :filter_by_date_range, ->(from_date, to_date) { date_range(from_date, to_date) }
+
+  # Sorting scopes for Sortable concern
+  scope :sort_by_date, ->(direction) { order(date: direction) }
+  scope :sort_by_amount, ->(direction) { order(amount: direction) }
+  scope :sort_by_description, ->(direction) { order(description: direction) }
+  scope :sort_by_transaction_type, ->(direction) { order(transaction_type: direction) }
+  scope :sort_by_merchant, ->(direction) { order(merchant: direction) }
+  scope :sort_by_category, ->(direction) { joins(:category).order('categories.name': direction) }
+  scope :sort_by_bank_account, ->(direction) { joins(bank_account: :bank).order('banks.name': direction) }
 
   # Instance methods to check transaction relevance
   def relevant_for_balance?

--- a/app/services/concerns/sortable.rb
+++ b/app/services/concerns/sortable.rb
@@ -2,41 +2,44 @@
 
 ##
 # Sortable
-# Concern for handling sorting logic in services
+# Generic concern for handling sorting logic in models
 #
 module Sortable
   extend ActiveSupport::Concern
 
-  private
+  module ClassMethods
+    ##
+    # Apply sorting to a scope based on permitted sort parameters
+    #
+    # @param permitted_sort_params [Hash] hash of permitted sort fields and their default directions
+    # @param raw_sort_params [ActionController::Parameters, Hash] raw parameters from request
+    # @return [ActiveRecord::Relation] the sorted scope
+    #
+    # Example usage:
+    #   Transaction.order_by(
+    #     { date: 'desc', amount: 'asc', description: 'asc' },
+    #     params[:sort]
+    #   )
+    #
+    def order_by(permitted_sort_params, raw_sort_params = nil)
+      results = all
 
-  ##
-  # Apply sorting to a scope based on sort parameters
-  #
-  # @param scope [ActiveRecord::Relation] the scope to sort
-  # @param sort_params [Hash] hash containing :sort and :direction keys
-  # @return [ActiveRecord::Relation] the sorted scope
-  #
-  def apply_sorting(scope, sort_params)
-    sort_field = sort_params[:sort] || "date"
-    direction = sort_params[:direction] || "desc"
+      sorting_params =
+        if raw_sort_params.present?
+          # Handle both ActionController::Parameters and Hash
+          raw_params = raw_sort_params.respond_to?(:to_unsafe_h) ? raw_sort_params.to_unsafe_h : raw_sort_params
+          # Use the values from raw_params, but only for keys that are permitted
+          raw_params.symbolize_keys.slice(*permitted_sort_params.keys)
+        else
+          permitted_sort_params
+        end
 
-    case sort_field
-    when "date"
-      scope.order(date: direction.to_sym)
-    when "amount"
-      scope.order(amount: direction.to_sym)
-    when "description"
-      scope.order(description: direction.to_sym)
-    when "transaction_type"
-      scope.order(transaction_type: direction.to_sym)
-    when "category"
-      scope.joins(:category).order('categories.name': direction.to_sym)
-    when "merchant"
-      scope.order(merchant: direction.to_sym)
-    when "bank_account"
-      scope.joins(bank_account: :bank).order('banks.name': direction.to_sym)
-    else
-      scope.order(date: :desc) # Default fallback
+      sorting_params.each do |key, value|
+        direction = value.to_s.casecmp("desc").zero? ? :desc : :asc
+        results = results.public_send(:"sort_by_#{key}", direction) if respond_to?(:"sort_by_#{key}")
+      end
+
+      results
     end
   end
 end

--- a/app/services/concerns/sortable.rb
+++ b/app/services/concerns/sortable.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+##
+# Sortable
+# Concern for handling sorting logic in services
+#
+module Sortable
+  extend ActiveSupport::Concern
+
+  private
+
+  ##
+  # Apply sorting to a scope based on sort parameters
+  #
+  # @param scope [ActiveRecord::Relation] the scope to sort
+  # @param sort_params [Hash] hash containing :sort and :direction keys
+  # @return [ActiveRecord::Relation] the sorted scope
+  #
+  def apply_sorting(scope, sort_params)
+    sort_field = sort_params[:sort] || "date"
+    direction = sort_params[:direction] || "desc"
+
+    case sort_field
+    when "date"
+      scope.order(date: direction.to_sym)
+    when "amount"
+      scope.order(amount: direction.to_sym)
+    when "description"
+      scope.order(description: direction.to_sym)
+    when "transaction_type"
+      scope.order(transaction_type: direction.to_sym)
+    when "category"
+      scope.joins(:category).order('categories.name': direction.to_sym)
+    when "merchant"
+      scope.order(merchant: direction.to_sym)
+    when "bank_account"
+      scope.joins(bank_account: :bank).order('banks.name': direction.to_sym)
+    else
+      scope.order(date: :desc) # Default fallback
+    end
+  end
+end

--- a/app/services/transactions/lister.rb
+++ b/app/services/transactions/lister.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+##
+# Transactions::Lister
+# Service for listing and filtering transactions with sorting capabilities
+#
+class Transactions::Lister < ApplicationService
+  include Sortable
+
+  def initialize(user, filter_params = {})
+    super()
+    @user = user
+    @filter_params = filter_params
+    @statement_file = nil
+  end
+
+  def call
+    load_transactions
+    return failure if has_errors?
+
+    success(build_response)
+  end
+
+  private
+
+  attr_reader :user, :filter_params, :statement_file
+
+  def load_transactions
+    # Start with base scope including necessary associations
+    @transactions = user.transactions.includes(:bank_account, :statement_file, :category)
+
+    # Apply filters using the Filterable concern
+    @transactions = @transactions.filter_by(filtering_params)
+
+    # Handle statement file special logic
+    handle_statement_file_filter
+
+    # Apply sorting
+    @transactions = apply_sorting(@transactions, sort_params)
+
+    # Store filtered scope for stats calculations
+    @filtered_transactions = @transactions
+  rescue => e
+    errors.add(:base, :loading_failed, message: "Failed to load transactions: #{e.message}")
+  end
+
+  def handle_statement_file_filter
+    return unless filter_params[:statement_file_id].present?
+
+    @statement_file = user.statement_files.find_by(id: filter_params[:statement_file_id])
+
+    unless @statement_file
+      errors.add(:base, :statement_file_not_found, message: "Statement file not found")
+      return
+    end
+
+    # Automatically include bank account filter when statement file is selected
+    unless filter_params[:bank_account_id].present?
+      @transactions = @transactions.where(bank_account_id: @statement_file.bank_account_id)
+    end
+  end
+
+  def filtering_params
+    # Map controller params to filter scope parameters
+    {
+      bank_account_id: filter_params[:bank_account_id],
+      statement_file_id: filter_params[:statement_file_id],
+      transaction_type: filter_params[:transaction_type],
+      from_date: filter_params[:from_date],
+      to_date: filter_params[:to_date]
+    }.compact
+  end
+
+  def sort_params
+    {
+      sort: filter_params[:sort] || "date",
+      direction: filter_params[:direction] || "desc"
+    }
+  end
+
+  def build_response
+    {
+      transactions: @transactions,
+      filtered_transactions: @filtered_transactions,
+      statement_file: @statement_file,
+      current_sort: sort_params[:sort],
+      current_direction: sort_params[:direction]
+    }
+  end
+end

--- a/app/services/transactions/lister.rb
+++ b/app/services/transactions/lister.rb
@@ -5,12 +5,10 @@
 # Service for listing and filtering transactions with sorting capabilities
 #
 class Transactions::Lister < ApplicationService
-  include Sortable
-
-  def initialize(user, filter_params = {})
+  def initialize(user, params = {})
     super()
     @user = user
-    @filter_params = filter_params
+    @params = params
     @statement_file = nil
   end
 
@@ -23,7 +21,7 @@ class Transactions::Lister < ApplicationService
 
   private
 
-  attr_reader :user, :filter_params, :statement_file
+  attr_reader :user, :params, :statement_file
 
   def load_transactions
     # Start with base scope including necessary associations
@@ -35,8 +33,8 @@ class Transactions::Lister < ApplicationService
     # Handle statement file special logic
     handle_statement_file_filter
 
-    # Apply sorting
-    @transactions = apply_sorting(@transactions, sort_params)
+    # Apply sorting using the model's Sortable concern
+    @transactions = @transactions.order_by(permitted_sort_params, build_sort_params)
 
     # Store filtered scope for stats calculations
     @filtered_transactions = @transactions
@@ -45,9 +43,9 @@ class Transactions::Lister < ApplicationService
   end
 
   def handle_statement_file_filter
-    return unless filter_params[:statement_file_id].present?
+    return unless params[:statement_file_id].present?
 
-    @statement_file = user.statement_files.find_by(id: filter_params[:statement_file_id])
+    @statement_file = user.statement_files.find_by(id: params[:statement_file_id])
 
     unless @statement_file
       errors.add(:base, :statement_file_not_found, message: "Statement file not found")
@@ -55,7 +53,7 @@ class Transactions::Lister < ApplicationService
     end
 
     # Automatically include bank account filter when statement file is selected
-    unless filter_params[:bank_account_id].present?
+    unless params[:bank_account_id].present?
       @transactions = @transactions.where(bank_account_id: @statement_file.bank_account_id)
     end
   end
@@ -63,18 +61,43 @@ class Transactions::Lister < ApplicationService
   def filtering_params
     # Map controller params to filter scope parameters
     {
-      bank_account_id: filter_params[:bank_account_id],
-      statement_file_id: filter_params[:statement_file_id],
-      transaction_type: filter_params[:transaction_type],
-      from_date: filter_params[:from_date],
-      to_date: filter_params[:to_date]
+      bank_account_id: params[:bank_account_id],
+      statement_file_id: params[:statement_file_id],
+      transaction_type: params[:transaction_type],
+      from_date: params[:from_date],
+      to_date: params[:to_date]
     }.compact
+  end
+
+  def permitted_sort_params
+    {
+      date: "desc",
+      amount: "desc",
+      description: "asc",
+      transaction_type: "asc",
+      merchant: "asc",
+      category: "asc",
+      bank_account: "asc"
+    }
+  end
+
+  def build_sort_params
+    sort_field = params[:sort] || "date"
+    direction = params[:direction] || "desc"
+
+    # Only include valid sort fields
+    if permitted_sort_params.key?(sort_field.to_sym)
+      { sort_field => direction }
+    else
+      # Fallback to default sort if invalid field provided
+      { "date" => "desc" }
+    end
   end
 
   def sort_params
     {
-      sort: filter_params[:sort] || "date",
-      direction: filter_params[:direction] || "desc"
+      sort: params[:sort] || "date",
+      direction: params[:direction] || "desc"
     }
   end
 

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -227,31 +227,31 @@
                   <span class="text-slate-700 font-medium">#</span>
                 </th>
                 <th class="transactions-table-header-row">
-                  <a class="transactions-table-header-sortable" href="/transactions?sort=date&direction=<%= @current_sort == 'date' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
+                  <a class="transactions-table-header-sortable" href="/transactions?sort=date&direction=<%= @current_sort == 'date' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&statement_file_id=<%= params[:statement_file_id] %>&transaction_type=<%= params[:transaction_type] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
                     <%= t('table_headers.date') %>
                     <%= render_sort_indicator('date') %>
                   </a>
                 </th>
                 <th class="transactions-table-header-row">
-                  <a class="transactions-table-header-sortable" href="/transactions?sort=description&direction=<%= @current_sort == 'description' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
+                  <a class="transactions-table-header-sortable" href="/transactions?sort=description&direction=<%= @current_sort == 'description' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&statement_file_id=<%= params[:statement_file_id] %>&transaction_type=<%= params[:transaction_type] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
                     <%= t('table_headers.description') %>
                     <%= render_sort_indicator('description') %>
                   </a>
                 </th>
                 <th class="transactions-table-header-row transactions-table-header-row-right">
-                  <a class="transactions-table-header-sortable" href="/transactions?sort=amount&direction=<%= @current_sort == 'amount' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
+                  <a class="transactions-table-header-sortable" href="/transactions?sort=amount&direction=<%= @current_sort == 'amount' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&statement_file_id=<%= params[:statement_file_id] %>&transaction_type=<%= params[:transaction_type] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
                     <%= t('table_headers.amount') %>
                     <%= render_sort_indicator('amount') %>
                   </a>
                 </th>
                 <th class="transactions-table-header-row">
-                  <a class="transactions-table-header-sortable" href="/transactions?sort=transaction_type&direction=<%= @current_sort == 'transaction_type' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
+                  <a class="transactions-table-header-sortable" href="/transactions?sort=transaction_type&direction=<%= @current_sort == 'transaction_type' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&statement_file_id=<%= params[:statement_file_id] %>&transaction_type=<%= params[:transaction_type] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
                     <%= t('table_headers.transaction_type') %>
                     <%= render_sort_indicator('transaction_type') %>
                   </a>
                 </th>
                 <th class="transactions-table-header-row">
-                  <a class="transactions-table-header-sortable" href="/transactions?sort=category&direction=<%= @current_sort == 'category' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
+                  <a class="transactions-table-header-sortable" href="/transactions?sort=category&direction=<%= @current_sort == 'category' && @current_direction == 'desc' ? 'asc' : 'desc' %>&bank_account_id=<%= params[:bank_account_id] %>&statement_file_id=<%= params[:statement_file_id] %>&transaction_type=<%= params[:transaction_type] %>&from_date=<%= params[:from_date] %>&to_date=<%= params[:to_date] %>&page=<%= params[:page] %>" onclick="preserveScrollPosition()">
                     <%= t('table_headers.category') %>
                     <%= render_sort_indicator('category') %>
                   </a>
@@ -571,7 +571,7 @@ function loadMoreTransactions() {
   
   // Preserve all current filter parameters
   const currentParams = new URLSearchParams(window.location.search);
-  ['bank_account_id', 'from_date', 'to_date', 'sort', 'direction'].forEach(param => {
+  ['bank_account_id', 'statement_file_id', 'transaction_type', 'from_date', 'to_date', 'sort', 'direction'].forEach(param => {
     if (currentParams.has(param)) {
       url.searchParams.set(param, currentParams.get(param));
     }

--- a/spec/services/concerns/sortable_spec.rb
+++ b/spec/services/concerns/sortable_spec.rb
@@ -1,14 +1,5 @@
 require 'rails_helper'
 
-# Test class to include the Sortable concern
-class TestSortableService
-  include Sortable
-
-  def test_apply_sorting(scope, sort_params)
-    apply_sorting(scope, sort_params)
-  end
-end
-
 RSpec.describe Sortable do
   let(:user) { create(:user) }
   let(:bank) { create(:bank) }
@@ -55,13 +46,12 @@ RSpec.describe Sortable do
            merchant: 'M Store')
   end
 
-  let(:service) { TestSortableService.new }
   let(:scope) { user.transactions.includes(:bank_account, :category) }
 
-  describe '#apply_sorting' do
+  describe '.order_by' do
     context 'sorting by date' do
-      it 'sorts by date descending by default' do
-        result = service.test_apply_sorting(scope, { sort: 'date', direction: 'desc' })
+      it 'sorts by date descending' do
+        result = scope.order_by({ date: 'desc' }, { date: 'desc' })
 
         transactions = result.to_a
         expect(transactions.first).to eq(transaction3) # Most recent
@@ -69,25 +59,25 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by date ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'date', direction: 'asc' })
+        result = scope.order_by({ date: 'asc' }, { date: 'asc' })
 
         transactions = result.to_a
         expect(transactions.first).to eq(transaction1)  # Oldest
         expect(transactions.last).to eq(transaction3)   # Most recent
       end
 
-      it 'defaults to date descending when no direction specified' do
-        result = service.test_apply_sorting(scope, { sort: 'date' })
+      it 'uses provided direction over default' do
+        result = scope.order_by({ date: 'desc' }, { date: 'asc' })
 
         transactions = result.to_a
-        expect(transactions.first).to eq(transaction3) # Most recent
-        expect(transactions.last).to eq(transaction1)  # Oldest
+        expect(transactions.first).to eq(transaction1)  # Oldest (asc)
+        expect(transactions.last).to eq(transaction3)   # Most recent (asc)
       end
     end
 
     context 'sorting by amount' do
       it 'sorts by amount descending' do
-        result = service.test_apply_sorting(scope, { sort: 'amount', direction: 'desc' })
+        result = scope.order_by({ amount: 'desc' }, { amount: 'desc' })
 
         transactions = result.to_a
         expect(transactions.first).to eq(transaction2)  # Highest amount (2500.00)
@@ -95,7 +85,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by amount ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'amount', direction: 'asc' })
+        result = scope.order_by({ amount: 'asc' }, { amount: 'asc' })
 
         transactions = result.to_a
         expect(transactions.first).to eq(transaction3)  # Lowest amount (-100.00)
@@ -105,7 +95,7 @@ RSpec.describe Sortable do
 
     context 'sorting by description' do
       it 'sorts by description ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'description', direction: 'asc' })
+        result = scope.order_by({ description: 'asc' }, { description: 'asc' })
 
         transactions = result.to_a
         expect(transactions.first.description).to eq('A Restaurant payment')
@@ -113,7 +103,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by description descending' do
-        result = service.test_apply_sorting(scope, { sort: 'description', direction: 'desc' })
+        result = scope.order_by({ description: 'desc' }, { description: 'desc' })
 
         transactions = result.to_a
         expect(transactions.first.description).to eq('Z Salary deposit')
@@ -123,7 +113,7 @@ RSpec.describe Sortable do
 
     context 'sorting by transaction_type' do
       it 'sorts by transaction_type ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'transaction_type', direction: 'asc' })
+        result = scope.order_by({ transaction_type: 'asc' }, { transaction_type: 'asc' })
 
         transactions = result.to_a
         expect(transactions.first.transaction_type).to eq('fixed_expense')
@@ -131,7 +121,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by transaction_type descending' do
-        result = service.test_apply_sorting(scope, { sort: 'transaction_type', direction: 'desc' })
+        result = scope.order_by({ transaction_type: 'desc' }, { transaction_type: 'desc' })
 
         transactions = result.to_a
         expect(transactions.first.transaction_type).to eq('variable_expense')
@@ -141,7 +131,7 @@ RSpec.describe Sortable do
 
     context 'sorting by category' do
       it 'sorts by category name ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'category', direction: 'asc' })
+        result = scope.order_by({ category: 'asc' }, { category: 'asc' })
 
         transactions = result.to_a
         # All transactions have the same category, so order should be preserved
@@ -150,7 +140,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by category name descending' do
-        result = service.test_apply_sorting(scope, { sort: 'category', direction: 'desc' })
+        result = scope.order_by({ category: 'desc' }, { category: 'desc' })
 
         transactions = result.to_a
         expect(transactions.count).to eq(3)
@@ -160,7 +150,7 @@ RSpec.describe Sortable do
 
     context 'sorting by merchant' do
       it 'sorts by merchant ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'merchant', direction: 'asc' })
+        result = scope.order_by({ merchant: 'asc' }, { merchant: 'asc' })
 
         transactions = result.to_a
         expect(transactions.first.merchant).to eq('A Company')
@@ -168,7 +158,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by merchant descending' do
-        result = service.test_apply_sorting(scope, { sort: 'merchant', direction: 'desc' })
+        result = scope.order_by({ merchant: 'desc' }, { merchant: 'desc' })
 
         transactions = result.to_a
         expect(transactions.first.merchant).to eq('Z Restaurant')
@@ -178,7 +168,7 @@ RSpec.describe Sortable do
 
     context 'sorting by bank_account' do
       it 'sorts by bank name ascending' do
-        result = service.test_apply_sorting(scope, { sort: 'bank_account', direction: 'asc' })
+        result = scope.order_by({ bank_account: 'asc' }, { bank_account: 'asc' })
 
         transactions = result.to_a
         expect(transactions.count).to eq(3)
@@ -186,7 +176,7 @@ RSpec.describe Sortable do
       end
 
       it 'sorts by bank name descending' do
-        result = service.test_apply_sorting(scope, { sort: 'bank_account', direction: 'desc' })
+        result = scope.order_by({ bank_account: 'desc' }, { bank_account: 'desc' })
 
         transactions = result.to_a
         expect(transactions.count).to eq(3)
@@ -194,39 +184,75 @@ RSpec.describe Sortable do
       end
     end
 
-    context 'invalid sort field' do
-      it 'falls back to date descending for invalid sort field' do
-        result = service.test_apply_sorting(scope, { sort: 'invalid_field', direction: 'asc' })
+    context 'with multiple sort parameters' do
+      it 'applies multiple sorts in order' do
+        result = scope.order_by(
+          { transaction_type: 'asc', amount: 'desc' },
+          { transaction_type: 'asc', amount: 'desc' }
+        )
 
         transactions = result.to_a
-        expect(transactions.first).to eq(transaction3) # Most recent (date desc)
-        expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
-      end
-
-      it 'falls back to date descending when sort field is nil' do
-        result = service.test_apply_sorting(scope, { sort: nil, direction: 'asc' })
-
-        transactions = result.to_a
-        expect(transactions.first).to eq(transaction1) # Oldest (date desc fallback)
-        expect(transactions.last).to eq(transaction3)  # Most recent (date desc fallback)
+        expect(transactions.count).to eq(3)
+        # Should be sorted by transaction_type first, then amount
       end
     end
 
-    context 'default parameters' do
-      it 'uses default sort and direction when not provided' do
-        result = service.test_apply_sorting(scope, {})
+    context 'with invalid sort fields' do
+      it 'ignores invalid sort fields' do
+        result = scope.order_by(
+          { date: 'desc', invalid_field: 'asc' },
+          { date: 'desc', invalid_field: 'asc' }
+        )
 
         transactions = result.to_a
         expect(transactions.first).to eq(transaction3) # Most recent (date desc)
         expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
       end
+    end
 
-      it 'uses default direction when only sort is provided' do
-        result = service.test_apply_sorting(scope, { sort: 'amount' })
+    context 'with no sort parameters' do
+      it 'uses default sort parameters' do
+        result = scope.order_by({ date: 'desc' })
 
         transactions = result.to_a
-        expect(transactions.first).to eq(transaction2)  # Highest amount (desc)
-        expect(transactions.last).to eq(transaction3)   # Lowest amount (desc)
+        expect(transactions.first).to eq(transaction3) # Most recent (date desc)
+        expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
+      end
+    end
+
+    context 'with empty sort parameters' do
+      it 'uses default sort parameters when empty hash provided' do
+        result = scope.order_by({ date: 'desc' }, {})
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent (date desc)
+        expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
+      end
+    end
+
+    context 'direction case handling' do
+      it 'handles uppercase direction' do
+        result = scope.order_by({ date: 'DESC' }, { date: 'DESC' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+
+      it 'handles mixed case direction' do
+        result = scope.order_by({ date: 'Desc' }, { date: 'Desc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+
+      it 'defaults to asc for non-desc values' do
+        result = scope.order_by({ date: 'asc' }, { date: 'invalid' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction1)  # Oldest (asc)
+        expect(transactions.last).to eq(transaction3)   # Most recent (asc)
       end
     end
   end

--- a/spec/services/concerns/sortable_spec.rb
+++ b/spec/services/concerns/sortable_spec.rb
@@ -1,0 +1,233 @@
+require 'rails_helper'
+
+# Test class to include the Sortable concern
+class TestSortableService
+  include Sortable
+
+  def test_apply_sorting(scope, sort_params)
+    apply_sorting(scope, sort_params)
+  end
+end
+
+RSpec.describe Sortable do
+  let(:user) { create(:user) }
+  let(:bank) { create(:bank) }
+  let(:bank_account) { create(:bank_account, user: user, bank: bank) }
+  let(:statement_file) { create(:statement_file, user: user, bank_account: bank_account) }
+  let(:category) { create(:category, user: user, name: 'Test Category') }
+
+  let!(:transaction1) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 15),
+           amount: -25.50,
+           transaction_type: 'variable_expense',
+           description: 'A Restaurant payment',
+           merchant: 'Z Restaurant')
+  end
+
+  let!(:transaction2) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 16),
+           amount: 2500.00,
+           transaction_type: 'income',
+           description: 'Z Salary deposit',
+           merchant: 'A Company')
+  end
+
+  let!(:transaction3) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 17),
+           amount: -100.00,
+           transaction_type: 'fixed_expense',
+           description: 'M Rent payment',
+           merchant: 'M Store')
+  end
+
+  let(:service) { TestSortableService.new }
+  let(:scope) { user.transactions.includes(:bank_account, :category) }
+
+  describe '#apply_sorting' do
+    context 'sorting by date' do
+      it 'sorts by date descending by default' do
+        result = service.test_apply_sorting(scope, { sort: 'date', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+
+      it 'sorts by date ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'date', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction1)  # Oldest
+        expect(transactions.last).to eq(transaction3)   # Most recent
+      end
+
+      it 'defaults to date descending when no direction specified' do
+        result = service.test_apply_sorting(scope, { sort: 'date' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+    end
+
+    context 'sorting by amount' do
+      it 'sorts by amount descending' do
+        result = service.test_apply_sorting(scope, { sort: 'amount', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction2)  # Highest amount (2500.00)
+        expect(transactions.last).to eq(transaction3)   # Lowest amount (-100.00)
+      end
+
+      it 'sorts by amount ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'amount', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3)  # Lowest amount (-100.00)
+        expect(transactions.last).to eq(transaction2)   # Highest amount (2500.00)
+      end
+    end
+
+    context 'sorting by description' do
+      it 'sorts by description ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'description', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first.description).to eq('A Restaurant payment')
+        expect(transactions.last.description).to eq('Z Salary deposit')
+      end
+
+      it 'sorts by description descending' do
+        result = service.test_apply_sorting(scope, { sort: 'description', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.first.description).to eq('Z Salary deposit')
+        expect(transactions.last.description).to eq('A Restaurant payment')
+      end
+    end
+
+    context 'sorting by transaction_type' do
+      it 'sorts by transaction_type ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'transaction_type', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first.transaction_type).to eq('fixed_expense')
+        expect(transactions.last.transaction_type).to eq('variable_expense')
+      end
+
+      it 'sorts by transaction_type descending' do
+        result = service.test_apply_sorting(scope, { sort: 'transaction_type', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.first.transaction_type).to eq('variable_expense')
+        expect(transactions.last.transaction_type).to eq('fixed_expense')
+      end
+    end
+
+    context 'sorting by category' do
+      it 'sorts by category name ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'category', direction: 'asc' })
+
+        transactions = result.to_a
+        # All transactions have the same category, so order should be preserved
+        expect(transactions.count).to eq(3)
+        expect(transactions.first.category.name).to eq('Test Category')
+      end
+
+      it 'sorts by category name descending' do
+        result = service.test_apply_sorting(scope, { sort: 'category', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.count).to eq(3)
+        expect(transactions.first.category.name).to eq('Test Category')
+      end
+    end
+
+    context 'sorting by merchant' do
+      it 'sorts by merchant ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'merchant', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first.merchant).to eq('A Company')
+        expect(transactions.last.merchant).to eq('Z Restaurant')
+      end
+
+      it 'sorts by merchant descending' do
+        result = service.test_apply_sorting(scope, { sort: 'merchant', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.first.merchant).to eq('Z Restaurant')
+        expect(transactions.last.merchant).to eq('A Company')
+      end
+    end
+
+    context 'sorting by bank_account' do
+      it 'sorts by bank name ascending' do
+        result = service.test_apply_sorting(scope, { sort: 'bank_account', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.count).to eq(3)
+        expect(transactions.first.bank_account.bank.name).to eq(bank.name)
+      end
+
+      it 'sorts by bank name descending' do
+        result = service.test_apply_sorting(scope, { sort: 'bank_account', direction: 'desc' })
+
+        transactions = result.to_a
+        expect(transactions.count).to eq(3)
+        expect(transactions.first.bank_account.bank.name).to eq(bank.name)
+      end
+    end
+
+    context 'invalid sort field' do
+      it 'falls back to date descending for invalid sort field' do
+        result = service.test_apply_sorting(scope, { sort: 'invalid_field', direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent (date desc)
+        expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
+      end
+
+      it 'falls back to date descending when sort field is nil' do
+        result = service.test_apply_sorting(scope, { sort: nil, direction: 'asc' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction1) # Oldest (date desc fallback)
+        expect(transactions.last).to eq(transaction3)  # Most recent (date desc fallback)
+      end
+    end
+
+    context 'default parameters' do
+      it 'uses default sort and direction when not provided' do
+        result = service.test_apply_sorting(scope, {})
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction3) # Most recent (date desc)
+        expect(transactions.last).to eq(transaction1)  # Oldest (date desc)
+      end
+
+      it 'uses default direction when only sort is provided' do
+        result = service.test_apply_sorting(scope, { sort: 'amount' })
+
+        transactions = result.to_a
+        expect(transactions.first).to eq(transaction2)  # Highest amount (desc)
+        expect(transactions.last).to eq(transaction3)   # Lowest amount (desc)
+      end
+    end
+  end
+end

--- a/spec/services/transactions/lister_spec.rb
+++ b/spec/services/transactions/lister_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Transactions::Lister do
   end
 
   describe '.call' do
-    context 'with no filters' do
+    context 'with no params' do
       it 'returns all user transactions' do
         result = described_class.call(user, {})
 

--- a/spec/services/transactions/lister_spec.rb
+++ b/spec/services/transactions/lister_spec.rb
@@ -1,0 +1,309 @@
+require 'rails_helper'
+
+RSpec.describe Transactions::Lister do
+  let(:user) { create(:user) }
+  let(:bank) { create(:bank) }
+  let(:bank_account) { create(:bank_account, user: user, bank: bank) }
+  let(:statement_file) { create(:statement_file, user: user, bank_account: bank_account) }
+  let(:category) { create(:category, user: user) }
+
+  let!(:transaction1) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 15),
+           amount: -25.50,
+           transaction_type: 'variable_expense',
+           description: 'Restaurant payment')
+  end
+
+  let!(:transaction2) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 16),
+           amount: 2500.00,
+           transaction_type: 'income',
+           description: 'Salary deposit')
+  end
+
+  let!(:transaction3) do
+    create(:transaction,
+           user: user,
+           bank_account: bank_account,
+           statement_file: statement_file,
+           category: category,
+           date: Date.new(2024, 3, 17),
+           amount: -100.00,
+           transaction_type: 'fixed_expense',
+           description: 'Rent payment')
+  end
+
+  describe '.call' do
+    context 'with no filters' do
+      it 'returns all user transactions' do
+        result = described_class.call(user, {})
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1, transaction2, transaction3)
+        expect(result.payload[:current_sort]).to eq('date')
+        expect(result.payload[:current_direction]).to eq('desc')
+      end
+    end
+
+    context 'with bank account filter' do
+      let(:other_bank_account) { create(:bank_account, user: user, bank: bank) }
+      let!(:other_transaction) do
+        create(:transaction,
+               user: user,
+               bank_account: other_bank_account,
+               statement_file: statement_file,
+               category: category)
+      end
+
+      it 'filters by bank account' do
+        result = described_class.call(user, { bank_account_id: bank_account.id })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1, transaction2, transaction3)
+        expect(result.payload[:transactions]).not_to include(other_transaction)
+      end
+    end
+
+    context 'with statement file filter' do
+      let(:other_statement_file) { create(:statement_file, user: user, bank_account: bank_account) }
+      let!(:other_transaction) do
+        create(:transaction,
+               user: user,
+               bank_account: bank_account,
+               statement_file: other_statement_file,
+               category: category)
+      end
+
+      it 'filters by statement file' do
+        result = described_class.call(user, { statement_file_id: statement_file.id })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1, transaction2, transaction3)
+        expect(result.payload[:transactions]).not_to include(other_transaction)
+        expect(result.payload[:statement_file]).to eq(statement_file)
+      end
+
+      it 'automatically includes bank account filter when statement file is selected' do
+        result = described_class.call(user, { statement_file_id: statement_file.id })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1, transaction2, transaction3)
+      end
+
+      it 'returns error when statement file not found' do
+        result = described_class.call(user, { statement_file_id: 99999 })
+
+        expect(result.success?).to be false
+        expect(result.errors.full_messages).to include('Statement file not found')
+      end
+    end
+
+    context 'with transaction type filter' do
+      it 'filters by income transactions' do
+        result = described_class.call(user, { transaction_type: 'income' })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction2)
+        expect(result.payload[:transactions]).not_to include(transaction1, transaction3)
+      end
+
+      it 'filters by variable expense transactions' do
+        result = described_class.call(user, { transaction_type: 'variable_expense' })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1)
+        expect(result.payload[:transactions]).not_to include(transaction2, transaction3)
+      end
+
+      it 'filters by fixed expense transactions' do
+        result = described_class.call(user, { transaction_type: 'fixed_expense' })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction3)
+        expect(result.payload[:transactions]).not_to include(transaction1, transaction2)
+      end
+    end
+
+    context 'with date range filter' do
+      it 'filters by from_date' do
+        result = described_class.call(user, { from_date: '2024-03-16' })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction2, transaction3)
+        expect(result.payload[:transactions]).not_to include(transaction1)
+      end
+
+      it 'filters by to_date' do
+        result = described_class.call(user, { to_date: '2024-03-16' })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1, transaction2)
+        expect(result.payload[:transactions]).not_to include(transaction3)
+      end
+
+      it 'filters by date range' do
+        result = described_class.call(user, {
+          from_date: '2024-03-16',
+          to_date: '2024-03-16'
+        })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction2)
+        expect(result.payload[:transactions]).not_to include(transaction1, transaction3)
+      end
+    end
+
+    context 'with sorting' do
+      it 'sorts by date descending by default' do
+        result = described_class.call(user, {})
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+
+      it 'sorts by date ascending' do
+        result = described_class.call(user, { sort: 'date', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first).to eq(transaction1)  # Oldest
+        expect(transactions.last).to eq(transaction3)   # Most recent
+      end
+
+      it 'sorts by amount descending' do
+        result = described_class.call(user, { sort: 'amount', direction: 'desc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first).to eq(transaction2)  # Highest amount (2500.00)
+        expect(transactions.last).to eq(transaction3)   # Lowest amount (-100.00)
+      end
+
+      it 'sorts by amount ascending' do
+        result = described_class.call(user, { sort: 'amount', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first).to eq(transaction3)  # Lowest amount (-100.00)
+        expect(transactions.last).to eq(transaction2)   # Highest amount (2500.00)
+      end
+
+      it 'sorts by description' do
+        result = described_class.call(user, { sort: 'description', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first.description).to eq('Rent payment')
+        expect(transactions.last.description).to eq('Salary deposit')
+      end
+
+      it 'sorts by transaction type' do
+        result = described_class.call(user, { sort: 'transaction_type', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first.transaction_type).to eq('fixed_expense')
+        expect(transactions.last.transaction_type).to eq('variable_expense')
+      end
+
+      it 'sorts by category name' do
+        result = described_class.call(user, { sort: 'category', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        # All transactions have the same category, so order should be preserved
+        expect(transactions.count).to eq(3)
+      end
+
+      it 'sorts by merchant' do
+        transaction1.update!(merchant: 'Z Restaurant')
+        transaction2.update!(merchant: 'A Company')
+        transaction3.update!(merchant: 'M Store')
+
+        result = described_class.call(user, { sort: 'merchant', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first.merchant).to eq('A Company')
+        expect(transactions.last.merchant).to eq('Z Restaurant')
+      end
+
+      it 'sorts by bank account name' do
+        bank.update!(name: 'Z Bank')
+
+        result = described_class.call(user, { sort: 'bank_account', direction: 'asc' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.count).to eq(3)
+      end
+
+      it 'falls back to date descending for invalid sort field' do
+        result = described_class.call(user, { sort: 'invalid_field' })
+
+        expect(result.success?).to be true
+        transactions = result.payload[:transactions]
+        expect(transactions.first).to eq(transaction3) # Most recent
+        expect(transactions.last).to eq(transaction1)  # Oldest
+      end
+    end
+
+    context 'with combined filters' do
+      it 'applies multiple filters correctly' do
+        result = described_class.call(user, {
+          transaction_type: 'variable_expense',
+          from_date: '2024-03-15',
+          to_date: '2024-03-15'
+        })
+
+        expect(result.success?).to be true
+        expect(result.payload[:transactions]).to include(transaction1)
+        expect(result.payload[:transactions]).not_to include(transaction2, transaction3)
+      end
+    end
+
+    context 'error handling' do
+      it 'handles database errors gracefully' do
+        allow(user.transactions).to receive(:includes).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+
+        result = described_class.call(user, {})
+
+        expect(result.success?).to be false
+        expect(result.errors.full_messages).to include(/Failed to load transactions/)
+      end
+    end
+
+    context 'response structure' do
+      it 'returns properly structured response' do
+        result = described_class.call(user, {})
+
+        expect(result.success?).to be true
+        payload = result.payload
+
+        expect(payload).to have_key(:transactions)
+        expect(payload).to have_key(:filtered_transactions)
+        expect(payload).to have_key(:statement_file)
+        expect(payload).to have_key(:current_sort)
+        expect(payload).to have_key(:current_direction)
+
+        expect(payload[:transactions]).to be_a(ActiveRecord::Relation)
+        expect(payload[:filtered_transactions]).to be_a(ActiveRecord::Relation)
+        expect(payload[:statement_file]).to be_nil
+        expect(payload[:current_sort]).to eq('date')
+        expect(payload[:current_direction]).to eq('desc')
+      end
+    end
+  end
+end


### PR DESCRIPTION
…er preservation

- Create Transactions::Lister service following SOLID/DRY principles
- Extract sorting logic into reusable Sortable concern
- Refactor TransactionsController#index to use service pattern
- Fix sorting links to preserve all filter parameters (transaction_type, statement_file_id)
- Add comprehensive test coverage for new service and concern
- Maintain all existing functionality including pagination and AJAX infinite scroll