### PR TITLE
feat: enhance transaction statistics and fix category handling

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1759,11 +1759,11 @@
   }
 
   .transactions-stats {
-    @apply grid grid-cols-1 md:grid-cols-4 gap-6 mb-8;
+    @apply grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 w-full max-w-none;
   }
 
   .transactions-stat-card {
-    @apply bg-white rounded-2xl p-6 shadow-lg border border-slate-200/60 hover:shadow-xl transition-all duration-300;
+    @apply bg-white rounded-2xl p-6 shadow-lg border border-slate-200/60 hover:shadow-xl transition-all duration-300 w-full;
   }
 
   .transactions-stat-card:hover {
@@ -1824,6 +1824,18 @@
 
   .transactions-stat-icon-svg-total {
     @apply text-blue-600;
+  }
+
+  .transactions-stat-icon-equity {
+    @apply bg-purple-100;
+  }
+
+  .transactions-stat-icon-svg-equity {
+    @apply text-purple-600;
+  }
+
+  .transactions-stat-value-equity {
+    @apply text-purple-600;
   }
 
   .transactions-table-container {

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -61,7 +61,10 @@ class Transaction < ApplicationRecord
   scope :sort_by_description, ->(direction) { order(description: direction) }
   scope :sort_by_transaction_type, ->(direction) { order(transaction_type: direction) }
   scope :sort_by_merchant, ->(direction) { order(merchant: direction) }
-  scope :sort_by_category, ->(direction) { joins(:category).order('categories.name': direction) }
+  scope :sort_by_category, ->(direction) {
+    left_joins(:category)
+      .order(Arel.sql("CASE WHEN categories.name IS NULL THEN 1 ELSE 0 END, categories.name #{direction}"))
+  }
   scope :sort_by_bank_account, ->(direction) { joins(bank_account: :bank).order('banks.name': direction) }
 
   # Search scopes for Searchable concern

--- a/app/services/category_template.rb
+++ b/app/services/category_template.rb
@@ -205,25 +205,17 @@ class CategoryTemplate
       parent: income_category
     )
 
-    # Create Uncategorized category with subcategories
-    uncategorized_category = user.categories.create!(
-      name: "Sin Categorizar"
-    )
-
-    # Uncategorized subcategories
+    # Create miscellaneous subcategories (no parent category needed)
     user.categories.create!(
-      name: "Gastos Varios",
-      parent: uncategorized_category
+      name: "Gastos Varios"
     )
 
     user.categories.create!(
-      name: "Transferencias",
-      parent: uncategorized_category
+      name: "Transferencias"
     )
 
     user.categories.create!(
-      name: "Comisiones",
-      parent: uncategorized_category
+      name: "Comisiones"
     )
   end
 end

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -186,43 +186,90 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2zm0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
             </svg>
           </div>
-          <div>
+          <div class="flex-1">
             <p class="transactions-stat-label"><%= t('table_headers.transactions') %></p>
             <p class="transactions-stat-value transactions-stat-value-total"><%= @pagy.count %></p>
+            <div class="mt-2 space-y-1">
+              <% 
+                income_count = @filtered_transactions.where(transaction_type: 'income').count
+                fixed_expense_count = @filtered_transactions.where(transaction_type: 'fixed_expense').count
+                variable_expense_count = @filtered_transactions.where(transaction_type: 'variable_expense').count
+              %>
+              <div class="flex justify-between text-xs">
+                <span class="text-green-600 flex items-center">
+                  <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
+                  </svg>
+                  <%= t('transaction_types.income') %>
+                </span>
+                <span class="text-green-600 font-medium"><%= income_count %></span>
+              </div>
+              <div class="flex justify-between text-xs">
+                <span class="text-red-600 flex items-center">
+                  <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                  </svg>
+                  <%= t('transaction_types.fixed_expense') %>
+                </span>
+                <span class="text-red-600 font-medium"><%= fixed_expense_count %></span>
+              </div>
+              <div class="flex justify-between text-xs">
+                <span class="text-orange-600 flex items-center">
+                  <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                  </svg>
+                  <%= t('transaction_types.variable_expense') %>
+                </span>
+                <span class="text-orange-600 font-medium"><%= variable_expense_count %></span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- INCOME STAT -->
+      <!-- EQUITY/UTILIDAD STAT -->
       <div class="transactions-stat-card">
         <div class="transactions-stat-content">
-          <div class="transactions-stat-icon transactions-stat-icon-income">
-            <svg class="transactions-stat-icon-svg transactions-stat-icon-svg-income" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
+          <div class="transactions-stat-icon transactions-stat-icon-equity">
+            <svg class="transactions-stat-icon-svg transactions-stat-icon-svg-equity" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
             </svg>
           </div>
-          <div>
-            <p class="transactions-stat-label"><%= t('transaction_types.income') %></p>
-            <p class="transactions-stat-value transactions-stat-value-income">
-              <%= number_to_currency(@filtered_transactions.where(transaction_type: 'income').sum(:amount), unit: "$") %>
+          <div class="flex-1">
+            <p class="transactions-stat-label"><%= t('transaction_types.equity') %></p>
+            <% 
+              income_total = @filtered_transactions.where(transaction_type: 'income').sum(:amount)
+              expenses_total = @filtered_transactions.where(transaction_type: ['fixed_expense', 'variable_expense']).sum(:amount)
+              equity_total = income_total + expenses_total
+            %>
+            <p class="transactions-stat-value <%= equity_total >= 0 ? 'text-green-600' : 'text-red-600' %>">
+              <%= number_to_currency(equity_total, unit: "$") %>
             </p>
-          </div>
-        </div>
-      </div>
-
-      <!-- EXPENSES STAT -->
-      <div class="transactions-stat-card">
-        <div class="transactions-stat-content">
-          <div class="transactions-stat-icon transactions-stat-icon-expenses">
-            <svg class="transactions-stat-icon-svg transactions-stat-icon-svg-expenses" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
-            </svg>
-          </div>
-          <div>
-            <p class="transactions-stat-label"><%= t('transaction_types.expenses') %></p>
-            <p class="transactions-stat-value transactions-stat-value-expenses">
-              <%= number_to_currency(@filtered_transactions.where(transaction_type: ['fixed_expense', 'variable_expense']).sum(:amount), unit: "$") %>
-            </p>
+            <!-- Income and Expenses breakdown -->
+            <div class="mt-2 space-y-1">
+              <div class="flex justify-between items-center text-xs">
+                <span class="text-green-600 flex items-center">
+                  <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
+                  </svg>
+                  <%= t('transaction_types.income') %>
+                </span>
+                <span class="text-green-600 font-medium">
+                  <%= number_to_currency(income_total, unit: "$") %>
+                </span>
+              </div>
+              <div class="flex justify-between items-center text-xs">
+                <span class="text-red-600 flex items-center">
+                  <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                  </svg>
+                  <%= t('transaction_types.expenses') %>
+                </span>
+                <span class="text-red-600 font-medium">
+                  <%= number_to_currency(expenses_total, unit: "$") %>
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -235,11 +282,43 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
             </svg>
           </div>
-          <div>
+          <div class="flex-1">
             <p class="transactions-stat-label"><%= t('navigation.categories') %></p>
             <p class="transactions-stat-value transactions-stat-value-total">
-              <%= @filtered_transactions.joins(:category).distinct.count(:category_id) %>
+              <%= @filtered_transactions.joins(:category).distinct.count(:category_id) + (@filtered_transactions.where(category_id: nil).count > 0 ? 1 : 0) %>
             </p>
+            <div class="mt-2 space-y-1">
+              <% 
+                # Use a different approach to avoid GROUP BY issues
+                category_counts = {}
+                @filtered_transactions.includes(:category).each do |transaction|
+                  if transaction.category
+                    category_name = transaction.category.name
+                  else
+                    category_name = t('transactions.no_category')
+                  end
+                  category_counts[category_name] = (category_counts[category_name] || 0) + 1
+                end
+                top_categories = category_counts.sort_by { |name, count| -count }.first(3).to_h
+              %>
+              <% if top_categories.any? %>
+                <% top_categories.each_with_index do |(category_name, count), index| %>
+                  <div class="flex justify-between text-xs">
+                    <span class="text-slate-600 flex items-center">
+                      <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
+                      </svg>
+                      <%= category_name %>
+                    </span>
+                    <span class="text-slate-600 font-medium"><%= count %></span>
+                  </div>
+                <% end %>
+              <% else %>
+                <div class="text-xs text-slate-500 italic">
+                  Sin categorías asignadas
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>
@@ -320,7 +399,7 @@
                   </td>
                   <td class="transactions-table-cell">
                     <span class="transactions-category">
-                      <%= transaction.transaction_type.humanize %>
+                      <%= t("transaction_types.#{transaction.transaction_type}") %>
                     </span>
                   </td>
                   <td class="transactions-table-cell">
@@ -454,7 +533,7 @@
           <label class="block text-sm font-medium text-slate-700 mb-2"><%= t('transactions.transaction_type') %></label>
           <select name="transaction[transaction_type]" id="edit_transaction_type" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
             <% Transaction.transaction_types.keys.each do |opt| %>
-              <option value="<%= opt %>"><%= opt.humanize %></option>
+              <option value="<%= opt %>"><%= t("transaction_types.#{opt}") %></option>
             <% end %>
           </select>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,7 @@ en:
     spending: "Spending"
     fixed_expense: "Fixed Expense"
     variable_expense: "Variable Expense"
+    equity: "Equity"
   
   # Investment and Savings Quotes
   quotes:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -433,6 +433,7 @@ es:
     spending: "Gastos"
     fixed_expense: "Gasto Fijo"
     variable_expense: "Gasto Variable"
+    equity: "Utilidad"
   
   # Investment and Savings Quotes
   quotes:


### PR DESCRIPTION
- Add transaction type breakdown to transactions card (income, fixed_expense, variable_expense counts)
- Add top 3 most repeated categories to categories card with transaction counts
- Replace separate income/expenses cards with unified equity/utility card showing net difference
- Add dynamic coloring for equity (green for positive, red for negative)
- Fix transaction type translations in table and forms (display Spanish instead of English)
- Remove 'Sin Categorizar' category from template, handle nil category_id as 'Sin Categoría'
- Fix category sorting to include uncategorized transactions (use left_joins instead of joins)
- Update stats cards layout to span full width with equal-sized floating cards
- Add equity translation to both English and Spanish locales