### PR TITLE
Phase 10 web form polish: segmented type control, AI buttons, $ currency

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -6,6 +6,7 @@ module Api
       before_action :require_confirmed_user!, only: %i[create update destroy]
       before_action :set_transaction, only: [:show, :update, :destroy]
       before_action :ensure_manual_transaction, only: [:update, :destroy]
+      before_action :check_ai_subscription!, only: [:parse_voice, :parse_image]
 
       # GET /api/v1/transactions
       def index
@@ -210,6 +211,13 @@ module Api
       end
 
       private
+
+      def check_ai_subscription!
+        result = current_user.subscription_access_result(i18n_scope: "ai_input.access_denied")
+        return if result[:allowed]
+
+        render_error("SUBSCRIPTION_REQUIRED", message: result[:message], status: :payment_required)
+      end
 
       def compute_frequency_days(merchant_key, cutoff)
         dates = current_user.transactions

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,7 @@
 class TransactionsController < ApplicationController
   before_action :require_confirmed_user!, only: %i[create update destroy]
   before_action :set_transaction, only: [:edit, :update, :destroy]
+  before_action :check_ai_subscription!, only: [:parse_voice, :parse_image]
 
   def index
     result = Transactions::Lister.call(request_params)
@@ -338,6 +339,13 @@ image/png image/webp].include?(mime_type)
   end
 
   private
+
+  def check_ai_subscription!
+    result = current_user.subscription_access_result(i18n_scope: "ai_input.access_denied")
+    return if result[:allowed]
+
+    render json: { error: result[:message], code: "SUBSCRIPTION_REQUIRED" }, status: :payment_required
+  end
 
   def parse_date_param(value)
     Date.parse(value) if value.present?

--- a/app/javascript/controllers/ai_input_controller.js
+++ b/app/javascript/controllers/ai_input_controller.js
@@ -40,7 +40,7 @@ export default class extends Controller {
 
     this._recognition.onresult = async (e) => {
       const transcript = e.results[0][0].transcript
-      this._setStatus(this._t("processing"))
+      this._setStatus(this._t("processing"), "indigo")
       await this._parseVoice(transcript)
     }
     this._recognition.onerror = () => {
@@ -76,11 +76,17 @@ export default class extends Controller {
         headers: { "Content-Type": "application/json", "X-CSRF-Token": this._csrf() },
         body: JSON.stringify({ text })
       })
+      if (res.status === 402) {
+        const data = await res.json()
+        this._setStatus(data.error || this._t("subscriptionRequired"), "amber")
+        setTimeout(() => this._setStatus(""), 5000)
+        return
+      }
       if (!res.ok) throw new Error()
       this._applyResult(await res.json())
       this._setStatus("")
     } catch {
-      this._setStatus(this._t("voiceError"))
+      this._setStatus(this._t("voiceError"), "red")
       setTimeout(() => this._setStatus(""), 3000)
     }
   }
@@ -101,11 +107,17 @@ export default class extends Controller {
         headers: { "Content-Type": "application/json", "X-CSRF-Token": this._csrf() },
         body: JSON.stringify({ image: base64, mime_type: file.type })
       })
+      if (res.status === 402) {
+        const data = await res.json()
+        this._setStatus(data.error || this._t("subscriptionRequired"), "amber")
+        setTimeout(() => this._setStatus(""), 5000)
+        return
+      }
       if (!res.ok) throw new Error()
       this._applyResult(await res.json())
       this._setStatus("")
     } catch {
-      this._setStatus(this._t("imageError"))
+      this._setStatus(this._t("imageError"), "red")
       setTimeout(() => this._setStatus(""), 3000)
     } finally {
       this.fileInputTarget.value = ""
@@ -156,8 +168,13 @@ export default class extends Controller {
 
   // ── Helpers ───────────────────────────────────────────────────────────────
 
-  _setStatus(msg) {
-    if (this.hasStatusLabelTarget) this.statusLabelTarget.textContent = msg
+  _setStatus(msg, color = "indigo") {
+    if (!this.hasStatusLabelTarget) return
+    const el = this.statusLabelTarget
+    el.textContent = msg
+    el.className = el.className.replace(/\btext-\w+-\d+\b/g, "")
+    const colorMap = { indigo: "text-indigo-600", red: "text-red-600", amber: "text-amber-600" }
+    el.classList.add(colorMap[color] || "text-indigo-600")
   }
 
   _setMicActive(active) {
@@ -190,8 +207,9 @@ export default class extends Controller {
       listening:     "Escuchando…",
       processing:    "Procesando…",
       readingReceipt:"Leyendo tu recibo…",
-      voiceError:    "No pude entender. Intenta de nuevo.",
-      imageError:    "No pude leer el recibo. Intenta de nuevo."
+      voiceError:          "No pude entender. Intenta de nuevo.",
+      imageError:          "No pude leer el recibo. Intenta de nuevo.",
+      subscriptionRequired:"Función disponible en el plan Pro."
     }
     return map[key] || ""
   }

--- a/app/javascript/controllers/transaction_form_controller.js
+++ b/app/javascript/controllers/transaction_form_controller.js
@@ -5,6 +5,10 @@ import { CurrencyFormatter } from "../utilities/currency_formatter"
 export default class extends Controller {
   static targets = [
     "transactionType",
+    "typeBtn",
+    "subTypeBtn",
+    "expenseSubTypeRow",
+    "transferSubTypeRow",
     "amount",
     "transferAccount",
     "transferField",
@@ -46,13 +50,84 @@ export default class extends Controller {
     requestAnimationFrame(() => {
       this.handleAmountSign()
       this.checkFormChanges()
+      // Initialize segmented type control (edit mode: restore correct button states)
+      if (this.hasTransactionTypeTarget) {
+        const currentType = this.transactionTypeTarget.value || 'variable_expense'
+        const topType = this._topTypeFrom(currentType)
+        this._updateTopTypeButtons(topType)
+        this._updateSubTypeRows(topType)
+        this._updateSubTypeButtons(currentType)
+      }
     })
   }
 
-  // Handle transaction type change
+  // Handle transaction type change (mobile web <select> path)
   handleTransactionTypeChange(event) {
     this.handleAmountSign()
     this.checkFormChanges()
+  }
+
+  // ── Segmented type control (desktop) ────────────────────────────────────
+
+  handleTopTypeClick(event) {
+    const topType = event.currentTarget.dataset.topType
+    const defaultSub = topType === 'income' ? 'income'
+                     : topType === 'transfer' ? 'transfer_out'
+                     : 'variable_expense'
+    this._setTransactionType(defaultSub)
+    this._updateTopTypeButtons(topType)
+    this._updateSubTypeRows(topType)
+    this._updateSubTypeButtons(defaultSub)
+  }
+
+  handleSubTypeClick(event) {
+    const subType = event.currentTarget.dataset.subType
+    this._setTransactionType(subType)
+    this._updateSubTypeButtons(subType)
+  }
+
+  _setTransactionType(type) {
+    if (this.hasTransactionTypeTarget) this.transactionTypeTarget.value = type
+    this.handleAmountSign()
+    this.checkFormChanges()
+  }
+
+  _topTypeFrom(subType) {
+    if (subType === 'income') return 'income'
+    if (subType === 'transfer_in' || subType === 'transfer_out') return 'transfer'
+    return 'expense'
+  }
+
+  _updateTopTypeButtons(activeTopType) {
+    const active = {
+      income:   ['bg-emerald-600', 'border-emerald-600', 'text-white'],
+      expense:  ['bg-rose-600',    'border-rose-600',    'text-white'],
+      transfer: ['bg-violet-600',  'border-violet-600',  'text-white'],
+    }
+    const inactive = ['bg-slate-50', 'border-slate-200', 'text-slate-600', 'hover:bg-slate-100']
+    const allActive = Object.values(active).flat()
+
+    this.typeBtnTargets.forEach(btn => {
+      const isActive = btn.dataset.topType === activeTopType
+      btn.classList.remove(...allActive, ...inactive)
+      btn.classList.add(...(isActive ? active[activeTopType] : inactive))
+    })
+  }
+
+  _updateSubTypeRows(topType) {
+    if (this.hasExpenseSubTypeRowTarget)
+      this.expenseSubTypeRowTarget.classList.toggle('hidden', topType !== 'expense')
+    if (this.hasTransferSubTypeRowTarget)
+      this.transferSubTypeRowTarget.classList.toggle('hidden', topType !== 'transfer')
+  }
+
+  _updateSubTypeButtons(activeSubType) {
+    const active   = ['bg-indigo-600', 'border-indigo-600', 'text-white']
+    const inactive = ['bg-white', 'border-slate-200', 'text-slate-600', 'hover:bg-slate-50']
+    this.subTypeBtnTargets.forEach(btn => {
+      btn.classList.remove(...active, ...inactive)
+      btn.classList.add(...(btn.dataset.subType === activeSubType ? active : inactive))
+    })
   }
 
   // Clear placeholder on focus (mobile amount input)
@@ -357,23 +432,23 @@ export default class extends Controller {
     this.updateCurrencySymbolColor(transactionType)
   }
 
-  // Update currency symbol color for standardized forms
+  // Update currency symbol, desktop amount input, and type chip colors
   updateCurrencySymbolColor(transactionType) {
-    if (!this.hasCurrencySymbolTarget) return
+    const isExpense = !['income', 'transfer_in', 'transfer_out'].includes(transactionType)
+    const isIncome = transactionType === 'income'
 
-    if (transactionType === 'transfer_out') {
-      // Transfers: neutral/default color
-      this.currencySymbolTarget.classList.remove('text-red-600', 'text-green-600')
-      this.currencySymbolTarget.classList.add('text-slate-500')
-    } else if (transactionType === 'income') {
-      // Income: green color
-      this.currencySymbolTarget.classList.remove('text-red-600', 'text-slate-500')
-      this.currencySymbolTarget.classList.add('text-green-600')
-    } else {
-      // Expenses: red color
-      this.currencySymbolTarget.classList.remove('text-green-600', 'text-slate-500')
-      this.currencySymbolTarget.classList.add('text-red-600')
+    // Currency symbol (MX$)
+    if (this.hasCurrencySymbolTarget) {
+      this.currencySymbolTarget.classList.remove('text-rose-600', 'text-emerald-600', 'text-violet-600')
+      this.currencySymbolTarget.classList.add(isExpense ? 'text-rose-600' : isIncome ? 'text-emerald-600' : 'text-violet-600')
     }
+
+    // Desktop amount input (bg-transparent = new hero style, not mobile)
+    if (this.hasAmountTarget && !this.hasAmountSignTarget) {
+      this.amountTarget.classList.remove('text-rose-600', 'text-emerald-600', 'text-violet-600')
+      this.amountTarget.classList.add(isExpense ? 'text-rose-600' : isIncome ? 'text-emerald-600' : 'text-violet-600')
+    }
+
   }
 
   // Toggle savings section visibility

--- a/app/views/transactions/_transaction_form.html.erb
+++ b/app/views/transactions/_transaction_form.html.erb
@@ -1,16 +1,15 @@
-<%# Transaction Form Partial - Standardized
+<%# Transaction Form Partial — Vittio design language
     Variables:
     - transaction: Transaction object (can be nil for new)
     - bank_accounts: collection of bank accounts
     - @categories: collection of parent categories with children
     - @savings: collection of active savings
     - @debts: collection of active debts
-    - show_amount: whether to show amount field (default: true)
+    - show_amount: whether to show amount + AI section (default: true, false on mobile pages)
     - show_submit: whether to show submit button (default: true)
 %>
 
 <% transaction ||= Transaction.new %>
-<% is_new = transaction.new_record? %>
 <% show_amount = local_assigns.fetch(:show_amount, true) %>
 <% show_submit = local_assigns.fetch(:show_submit, true) %>
 <% return_to = local_assigns.fetch(:return_to, nil) %>
@@ -26,225 +25,312 @@
                 transaction_form_target: "form",
                 action: "submit->transaction-form#submit"
               },
-              class: "space-y-6") do |f| %>
+              class: "space-y-5") do |f| %>
 
   <% if return_to.present? %>
     <%= hidden_field_tag :return_to, return_to %>
   <% end %>
 
-  <!-- AI Input Row: voice + receipt (hidden on unsupported browsers via JS) -->
   <% if show_amount %>
-    <div class="flex items-center gap-2 p-3 bg-slate-50 rounded-xl border border-slate-200">
-      <%# Mic button — JS hides this if SpeechRecognition is unavailable %>
-      <button type="button"
-              data-ai-input-target="micButton"
-              data-action="click->ai-input#toggleMic"
-              class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-slate-600 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors"
-              title="<%= t('ai_input.voice.tap') %>">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M12 1a4 4 0 0 1 4 4v6a4 4 0 0 1-8 0V5a4 4 0 0 1 4-4z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M19 10v1a7 7 0 0 1-14 0v-1M12 18v4M8 22h8"/>
-        </svg>
-        <span class="hidden sm:inline"><%= t('ai_input.voice.tap') %></span>
-      </button>
+    <!-- Amount Hero (desktop) -->
+    <div class="text-center py-4">
+      <div class="flex items-baseline justify-center gap-2">
+        <span data-transaction-form-target="currencySymbol"
+              class="text-xl font-semibold transition-colors text-rose-600">$</span>
+        <%= f.text_field :amount,
+            value: transaction.persisted? ? number_with_precision(transaction.amount.abs, precision: 2, delimiter: ',') : nil,
+            inputmode: "decimal",
+            required: true,
+            "data-ai-amount": "",
+            style: "width: 8ch; min-width: 5ch; max-width: 15ch;",
+            data: {
+              controller: "currency-input",
+              transaction_form_target: "amount",
+              action: "input->transaction-form#handleAmountInput blur->transaction-form#handleAmountBlur"
+            },
+            class: "text-3xl font-bold text-center text-rose-600 bg-transparent border-0 border-b-2 border-slate-200 rounded-none focus:ring-0 focus:border-indigo-400 transition-colors",
+            placeholder: "0.00" %>
+      </div>
 
-      <%# Receipt image picker %>
-      <label class="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-slate-600 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors"
-             title="<%= t('ai_input.camera.tap') %>">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M3 9a2 2 0 0 1 2-2h.93a2 2 0 0 0 1.664-.89l.812-1.22A2 2 0 0 1 10.07 4h3.86a2 2 0 0 1 1.664.89l.812 1.22A2 2 0 0 0 18.07 7H19a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9z"/>
-          <circle cx="12" cy="13" r="3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-        </svg>
-        <span class="hidden sm:inline"><%= t('ai_input.camera.tap') %></span>
-        <input type="file"
-               accept="image/jpeg,image/png,image/webp"
-               class="sr-only"
-               data-ai-input-target="fileInput"
-               data-action="change->ai-input#uploadFile">
-      </label>
+      <% if transaction.errors[:amount].any? %>
+        <p class="mt-2 text-sm text-red-600"><%= transaction.errors[:amount].first %></p>
+      <% end %>
 
-      <span data-ai-input-target="statusLabel"
-            class="text-sm text-indigo-600 font-medium ml-1 flex-1"></span>
+      <!-- 3-button segmented type control (matches mobile design) -->
+      <div class="flex justify-center mt-4 gap-2">
+        <button type="button"
+                data-transaction-form-target="typeBtn"
+                data-action="click->transaction-form#handleTopTypeClick"
+                data-top-type="income"
+                class="flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-medium transition-colors bg-slate-50 border-slate-200 text-slate-600 hover:bg-slate-100">
+          <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+          </svg>
+          Ingreso
+        </button>
+        <button type="button"
+                data-transaction-form-target="typeBtn"
+                data-action="click->transaction-form#handleTopTypeClick"
+                data-top-type="expense"
+                class="flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-medium transition-colors bg-rose-600 border-rose-600 text-white">
+          <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0v-8m0 8l-8-8-4 4-6-6"/>
+          </svg>
+          Gasto
+        </button>
+        <button type="button"
+                data-transaction-form-target="typeBtn"
+                data-action="click->transaction-form#handleTopTypeClick"
+                data-top-type="transfer"
+                class="flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-medium transition-colors bg-slate-50 border-slate-200 text-slate-600 hover:bg-slate-100">
+          <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+          </svg>
+          Transferencia
+        </button>
+      </div>
+
+      <!-- Expense sub-type (Variable / Fijo) -->
+      <div class="flex justify-center mt-2 gap-2" data-transaction-form-target="expenseSubTypeRow">
+        <button type="button"
+                data-transaction-form-target="subTypeBtn"
+                data-action="click->transaction-form#handleSubTypeClick"
+                data-sub-type="variable_expense"
+                class="px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors bg-indigo-600 border-indigo-600 text-white">
+          Variable
+        </button>
+        <button type="button"
+                data-transaction-form-target="subTypeBtn"
+                data-action="click->transaction-form#handleSubTypeClick"
+                data-sub-type="fixed_expense"
+                class="px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors bg-white border-slate-200 text-slate-600 hover:bg-slate-50">
+          Fijo
+        </button>
+      </div>
+
+      <!-- Transfer sub-type (Salida / Entrada) -->
+      <div class="flex justify-center mt-2 gap-2 hidden" data-transaction-form-target="transferSubTypeRow">
+        <button type="button"
+                data-transaction-form-target="subTypeBtn"
+                data-action="click->transaction-form#handleSubTypeClick"
+                data-sub-type="transfer_out"
+                class="px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors bg-indigo-600 border-indigo-600 text-white">
+          Salida
+        </button>
+        <button type="button"
+                data-transaction-form-target="subTypeBtn"
+                data-action="click->transaction-form#handleSubTypeClick"
+                data-sub-type="transfer_in"
+                class="px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors bg-white border-slate-200 text-slate-600 hover:bg-slate-50">
+          Entrada
+        </button>
+      </div>
+
+      <%# Hidden field — drives form submission, replaces the visible select %>
+      <%= f.hidden_field :transaction_type,
+          value: transaction.transaction_type || 'variable_expense',
+          data: {
+            transaction_form_target: "transactionType",
+            "ai-type": ""
+          } %>
+
+      <% if transaction.errors[:transaction_type].any? %>
+        <p class="mt-2 text-sm text-red-600"><%= transaction.errors[:transaction_type].first %></p>
+      <% end %>
     </div>
-  <% end %>
 
-  <!-- Date and Amount Fields (side by side at top when both shown, otherwise stacked) -->
-  <% if show_amount %>
-    <!-- Desktop: Date and Amount side by side -->
+    <hr class="border-slate-100">
+
+    <!-- Description (desktop: above date+account) -->
+    <div>
+      <%= f.label :description, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+        <%= t('transactions.transaction_description') %>
+        <span class="text-red-400">*</span>
+      <% end %>
+      <%= f.text_field :description,
+          required: true,
+          "data-ai-description": "",
+          class: "w-full px-4 py-2.5 border #{transaction.errors[:description].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors",
+          placeholder: t('transactions.transaction_description_placeholder') %>
+      <% if transaction.errors[:description].any? %>
+        <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:description].first %></p>
+      <% end %>
+    </div>
+
+    <!-- Account + Date (two-column on desktop) -->
     <div class="flex gap-4">
-      <!-- Date Field -->
-      <div class="flex-1 w-0">
-        <%= f.label :date, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+      <div class="flex-1 min-w-0">
+        <%= f.label :bank_account_id, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+          <%= t('transactions.select_bank_account') %>
+          <span class="text-red-400">*</span>
+        <% end %>
+        <%= f.select :bank_account_id,
+            bank_accounts.map { |ba| ["#{ba.custom_name || ba.display_name} - #{ba.cash? ? t('account_type.cash') : "•••#{ba.account_number.last(4)}"}", ba.id] },
+            { prompt: t('transactions.select_source_account'), selected: transaction.bank_account_id },
+            {
+              required: true,
+              class: "w-full px-4 py-2.5 border #{transaction.errors[:bank_account_id].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+            } %>
+        <% if transaction.errors[:bank_account_id].any? %>
+          <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:bank_account_id].first %></p>
+        <% end %>
+      </div>
+
+      <div class="flex-1 min-w-0">
+        <%= f.label :date, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
           <%= t('transactions.transaction_date') %>
-          <span class="text-red-500">*</span>
+          <span class="text-red-400">*</span>
         <% end %>
         <%= f.date_field :date,
             value: transaction.date&.to_s,
             required: true,
             max: Date.current.to_s,
             "data-ai-date": "",
-            class: "w-full px-4 py-2 border #{transaction.errors[:date].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+            class: "w-full px-4 py-2.5 border #{transaction.errors[:date].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors" %>
         <% if transaction.errors[:date].any? %>
           <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:date].first %></p>
         <% else %>
-          <p class="mt-1 text-sm text-slate-500"><%= t('transactions.date_help') %></p>
-        <% end %>
-      </div>
-
-      <!-- Amount Field with Currency Input -->
-      <div class="flex-1 w-0">
-        <%= f.label :amount, class: "block text-sm font-medium text-slate-700 mb-2" do %>
-          <%= t('transactions.amount') %>
-          <span class="text-red-500">*</span>
-        <% end %>
-        <div class="relative w-full">
-          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span data-transaction-form-target="currencySymbol" class="text-slate-500 sm:text-sm transition-colors">$</span>
-          </div>
-          <%= f.text_field :amount,
-              value: transaction.persisted? ? number_with_precision(transaction.amount.abs, precision: 2, delimiter: ',') : nil,
-              inputmode: "decimal",
-              required: true,
-              "data-ai-amount": "",
-              data: {
-                controller: "currency-input",
-                transaction_form_target: "amount",
-                action: "input->transaction-form#handleAmountInput blur->transaction-form#handleAmountBlur"
-              },
-              class: "w-full pl-7 pr-3 py-2 border #{transaction.errors[:amount].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors",
-              placeholder: "0.00" %>
-        </div>
-        <% if transaction.errors[:amount].any? %>
-          <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:amount].first %></p>
-        <% else %>
-          <p class="mt-1 text-sm text-slate-500"><%= t('transactions.amount_help') %></p>
+          <p class="mt-1 text-xs text-slate-400"><%= t('transactions.date_help') %></p>
         <% end %>
       </div>
     </div>
+
   <% else %>
-    <!-- Mobile: Date only (amount shown separately above form) -->
+    <!-- Mobile: Date → Type → Account stacked -->
     <div>
-      <%= f.label :date, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+      <%= f.label :date, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
         <%= t('transactions.transaction_date') %>
-        <span class="text-red-500">*</span>
+        <span class="text-red-400">*</span>
       <% end %>
       <%= f.date_field :date,
           value: transaction.date&.to_s,
           required: true,
           max: Date.current.to_s,
-          class: "w-full px-4 py-2 border #{transaction.errors[:date].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          "data-ai-date": "",
+          class: "w-full px-4 py-2.5 border #{transaction.errors[:date].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors" %>
       <% if transaction.errors[:date].any? %>
         <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:date].first %></p>
       <% else %>
-        <p class="mt-1 text-sm text-slate-500"><%= t('transactions.date_help') %></p>
+        <p class="mt-1 text-xs text-slate-400"><%= t('transactions.date_help') %></p>
+      <% end %>
+    </div>
+
+    <div>
+      <%= f.label :transaction_type, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+        <%= t('transactions.transaction_type') %>
+        <span class="text-red-400">*</span>
+      <% end %>
+      <%= f.select :transaction_type,
+          Transaction.transaction_types.keys.reject { |k| k == 'transfer_in' }.map { |t| [t('transaction_types.' + t), t] },
+          { selected: transaction.transaction_type || 'variable_expense' },
+          {
+            required: true,
+            "data-ai-type": "",
+            data: {
+              transaction_form_target: "transactionType",
+              action: "change->transaction-form#handleTransactionTypeChange"
+            },
+            class: "w-full px-4 py-2.5 border #{transaction.errors[:transaction_type].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+          } %>
+      <% if transaction.errors[:transaction_type].any? %>
+        <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:transaction_type].first %></p>
+      <% end %>
+    </div>
+
+    <div>
+      <%= f.label :bank_account_id, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+        <%= t('transactions.select_bank_account') %>
+        <span class="text-red-400">*</span>
+      <% end %>
+      <%= f.select :bank_account_id,
+          bank_accounts.map { |ba| ["#{ba.custom_name || ba.display_name} - #{ba.cash? ? t('account_type.cash') : "•••#{ba.account_number.last(4)}"}", ba.id] },
+          { prompt: t('transactions.select_source_account'), selected: transaction.bank_account_id },
+          {
+            required: true,
+            class: "w-full px-4 py-2.5 border #{transaction.errors[:bank_account_id].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+          } %>
+      <% if transaction.errors[:bank_account_id].any? %>
+        <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:bank_account_id].first %></p>
       <% end %>
     </div>
   <% end %>
 
-  <!-- Transaction Type Field (determines colors) -->
-  <div>
-    <%= f.label :transaction_type, class: "block text-sm font-medium text-slate-700 mb-2" do %>
-      <%= t('transactions.transaction_type') %>
-      <span class="text-red-500">*</span>
-    <% end %>
-    <%= f.select :transaction_type,
-        Transaction.transaction_types.keys.reject { |k| k == 'transfer_in' }.map { |t| [t('transaction_types.' + t), t] },
-        { selected: transaction.transaction_type || 'variable_expense' },
-        {
-          required: true,
-          "data-ai-type": "",
-          data: {
-            transaction_form_target: "transactionType",
-            action: "change->transaction-form#handleTransactionTypeChange"
-          },
-          class: "w-full px-4 py-2 border #{transaction.errors[:transaction_type].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        } %>
-    <% if transaction.errors[:transaction_type].any? %>
-      <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:transaction_type].first %></p>
-    <% end %>
-  </div>
-
-  <!-- Bank Account Field -->
-  <div>
-    <%= f.label :bank_account_id, class: "block text-sm font-medium text-slate-700 mb-2" do %>
-      <%= t('transactions.select_bank_account') %>
-      <span class="text-red-500">*</span>
-    <% end %>
-    <%= f.select :bank_account_id,
-        bank_accounts.map { |ba| ["#{ba.custom_name || ba.display_name} - #{ba.cash? ? t('account_type.cash') : "•••#{ba.account_number.last(4)}"}", ba.id] },
-        { prompt: t('transactions.select_source_account'), selected: transaction.bank_account_id },
-        {
-          required: true,
-          class: "w-full px-4 py-2 border #{transaction.errors[:bank_account_id].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        } %>
-    <% if transaction.errors[:bank_account_id].any? %>
-      <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:bank_account_id].first %></p>
-    <% end %>
-  </div>
-
-  <!-- Transfer Account Field (shown only for transfers) -->
+  <!-- Transfer Account (conditional, both views) -->
   <div data-transaction-form-target="transferField" class="<%= transaction.ttype_transfer_out? ? '' : 'hidden' %>">
-    <%= f.label :transfer_account_id, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+    <%= f.label :transfer_account_id, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
       <%= t('transactions.transfer_to') %>
-      <span class="text-red-500">*</span>
+      <span class="text-red-400">*</span>
     <% end %>
     <%= f.select :transfer_account_id,
         bank_accounts.map { |ba| ["#{ba.custom_name || ba.display_name} - #{ba.cash? ? t('account_type.cash') : "•••#{ba.account_number.last(4)}"}", ba.id] },
         { prompt: t('transactions.select_destination_account'), selected: transaction.linked_transfer&.bank_account_id },
         {
           data: { transaction_form_target: "transferAccount" },
-          class: "w-full px-4 py-2 border #{transaction.errors[:transfer_account_id].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          class: "w-full px-4 py-2.5 border #{transaction.errors[:transfer_account_id].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
         } %>
     <% if transaction.errors[:transfer_account_id].any? %>
       <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:transfer_account_id].first %></p>
     <% end %>
   </div>
 
-  <!-- Description Field -->
-  <div>
-    <%= f.label :description, class: "block text-sm font-medium text-slate-700 mb-2" do %>
-      <%= t('transactions.transaction_description') %>
-      <span class="text-red-500">*</span>
-    <% end %>
-    <%= f.text_field :description,
-        required: true,
-        "data-ai-description": "",
-        class: "w-full px-4 py-2 border #{transaction.errors[:description].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
-        placeholder: t('transactions.transaction_description_placeholder') %>
-    <% if transaction.errors[:description].any? %>
-      <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:description].first %></p>
-    <% end %>
-  </div>
+  <hr class="border-slate-100">
 
-  <!-- Category Field (Optional) -->
+  <% unless show_amount %>
+    <!-- Description (mobile path: after account) -->
+    <div>
+      <%= f.label :description, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+        <%= t('transactions.transaction_description') %>
+        <span class="text-red-400">*</span>
+      <% end %>
+      <%= f.text_field :description,
+          required: true,
+          "data-ai-description": "",
+          class: "w-full px-4 py-2.5 border #{transaction.errors[:description].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors",
+          placeholder: t('transactions.transaction_description_placeholder') %>
+      <% if transaction.errors[:description].any? %>
+        <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:description].first %></p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <!-- Category (Optional) -->
   <div>
-    <%= f.label :category_id, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+    <%= f.label :category_id, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
       <%= t('transactions.category') %>
-      <span class="text-slate-400 text-xs">(<%= t('form_actions.optional') %>)</span>
+      <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
     <% end %>
-
     <%= render "shared/category_picker",
       categories: @categories,
       selected_id: transaction.category_id,
       field_name: "transaction[category_id]",
       placeholder: t("transactions.select_category") %>
-
     <% if transaction.errors[:category_id].any? %>
       <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:category_id].first %></p>
     <% end %>
   </div>
 
-  <!-- Merchant Field (Optional) -->
+  <!-- Concept (Optional) -->
   <div>
-    <%= f.label :merchant, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+    <%= f.label :concept, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
+      <%= t('transactions.concept') %>
+      <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
+    <% end %>
+    <%= f.text_field :concept,
+        class: "w-full px-4 py-2.5 border #{transaction.errors[:concept].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors",
+        placeholder: t('transactions.concept_placeholder', default: 'Más detalles...') %>
+    <% if transaction.errors[:concept].any? %>
+      <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:concept].first %></p>
+    <% end %>
+  </div>
+
+  <!-- Merchant (Optional) -->
+  <div>
+    <%= f.label :merchant, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
       <%= t('transactions.merchant') %>
-      <span class="text-slate-400 text-xs">(<%= t('form_actions.optional') %>)</span>
+      <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
     <% end %>
     <%= f.text_field :merchant,
-        class: "w-full px-4 py-2 border #{transaction.errors[:merchant].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
+        class: "w-full px-4 py-2.5 border #{transaction.errors[:merchant].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors",
         placeholder: t('transactions.merchant_placeholder'),
         data: {
           merchant_suggest_target: "merchant",
@@ -255,14 +341,14 @@
     <% end %>
   </div>
 
-  <!-- Reference Field (Optional) -->
+  <!-- Reference (Optional) -->
   <div>
-    <%= f.label :reference, class: "block text-sm font-medium text-slate-700 mb-2" do %>
+    <%= f.label :reference, class: "block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2" do %>
       <%= t('transactions.reference') %>
-      <span class="text-slate-400 text-xs">(<%= t('form_actions.optional') %>)</span>
+      <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
     <% end %>
     <%= f.text_field :reference,
-        class: "w-full px-4 py-2 border #{transaction.errors[:reference].any? ? 'border-red-500' : 'border-slate-300'} rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
+        class: "w-full px-4 py-2.5 border #{transaction.errors[:reference].any? ? 'border-red-500' : 'border-slate-200'} rounded-xl bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors",
         placeholder: t('transactions.reference_placeholder') %>
     <% if transaction.errors[:reference].any? %>
       <p class="mt-1 text-sm text-red-600"><%= transaction.errors[:reference].first %></p>
@@ -272,37 +358,34 @@
   <%# Link to Savings and Debts sections — deferred features, hidden for now %>
   <%# To re-enable, remove the `false &&` guard from both blocks below %>
   <% if false && @savings.any? %>
-    <!-- Link to Savings (Optional) -->
     <div>
       <div class="flex items-center justify-between mb-2">
-        <label class="block text-sm font-medium text-slate-700">
+        <label class="block text-xs font-semibold uppercase tracking-wide text-slate-400">
           <%= t('transactions.link_to_savings') %>
-          <span class="text-slate-400 text-xs">(<%= t('form_actions.optional') %>)</span>
+          <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
         </label>
         <button type="button"
                 data-action="click->transaction-form#toggleSavings"
-                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors">
+                class="flex items-center space-x-1 text-sm text-indigo-600 hover:text-indigo-700 font-medium transition-colors">
           <span data-transaction-form-target="savingsToggleText"
                 data-show-text="<%= t('transactions.show_savings', default: 'Show Savings') %>"
                 data-hide-text="<%= t('transactions.hide_savings', default: 'Hide Savings') %>"><%= t('transactions.show_savings', default: 'Show Savings') %></span>
           <svg data-transaction-form-target="savingsToggleIcon"
                class="w-4 h-4 transform transition-transform"
-               fill="none"
-               stroke="currentColor"
-               viewBox="0 0 24 24">
+               fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
       </div>
-      <div class="space-y-2 max-h-40 overflow-y-auto border border-slate-200 rounded-lg p-3 hidden"
+      <div class="space-y-2 max-h-40 overflow-y-auto border border-slate-200 rounded-xl p-3 hidden"
            data-transaction-form-target="savingsContainer">
         <% @savings.each do |saving| %>
-          <label class="flex items-center space-x-2 cursor-pointer hover:bg-slate-50 p-2 rounded">
+          <label class="flex items-center space-x-2 cursor-pointer hover:bg-slate-50 p-2 rounded-lg">
             <%= check_box_tag 'transaction[saving_ids][]', saving.id,
                 transaction.savings.include?(saving),
                 id: "transaction_saving_ids_#{saving.id}",
                 data: { transaction_form_target: "savingCheckbox" },
-                class: "rounded border-slate-300 text-blue-600 focus:ring-blue-500" %>
+                class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" %>
             <span class="text-sm text-slate-700"><%= saving.name %></span>
           </label>
         <% end %>
@@ -311,37 +394,34 @@
   <% end %>
 
   <% if false && @debts.any? %>
-    <!-- Link to Debts (Optional) -->
     <div>
       <div class="flex items-center justify-between mb-2">
-        <label class="block text-sm font-medium text-slate-700">
+        <label class="block text-xs font-semibold uppercase tracking-wide text-slate-400">
           <%= t('transactions.link_to_debts') %>
-          <span class="text-slate-400 text-xs">(<%= t('form_actions.optional') %>)</span>
+          <span class="text-slate-300 text-xs normal-case font-normal tracking-normal">(<%= t('form_actions.optional') %>)</span>
         </label>
         <button type="button"
                 data-action="click->transaction-form#toggleDebts"
-                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors">
+                class="flex items-center space-x-1 text-sm text-indigo-600 hover:text-indigo-700 font-medium transition-colors">
           <span data-transaction-form-target="debtsToggleText"
                 data-show-text="<%= t('transactions.show_debts', default: 'Show Debts') %>"
                 data-hide-text="<%= t('transactions.hide_debts', default: 'Hide Debts') %>"><%= t('transactions.show_debts', default: 'Show Debts') %></span>
           <svg data-transaction-form-target="debtsToggleIcon"
                class="w-4 h-4 transform transition-transform"
-               fill="none"
-               stroke="currentColor"
-               viewBox="0 0 24 24">
+               fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
           </svg>
         </button>
       </div>
-      <div class="space-y-2 max-h-40 overflow-y-auto border border-slate-200 rounded-lg p-3 hidden"
+      <div class="space-y-2 max-h-40 overflow-y-auto border border-slate-200 rounded-xl p-3 hidden"
            data-transaction-form-target="debtsContainer">
         <% @debts.each do |debt| %>
-          <label class="flex items-center space-x-2 cursor-pointer hover:bg-slate-50 p-2 rounded">
+          <label class="flex items-center space-x-2 cursor-pointer hover:bg-slate-50 p-2 rounded-lg">
             <%= check_box_tag 'transaction[debt_ids][]', debt.id,
                 transaction.debts.include?(debt),
                 id: "transaction_debt_ids_#{debt.id}",
                 data: { transaction_form_target: "debtCheckbox" },
-                class: "rounded border-slate-300 text-blue-600 focus:ring-blue-500" %>
+                class: "rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" %>
             <span class="text-sm text-slate-700"><%= debt.name %></span>
           </label>
         <% end %>
@@ -349,11 +429,42 @@
     </div>
   <% end %>
 
-  <!-- Submit Button -->
+  <!-- AI Input (web only — desktop form) -->
+  <% if show_amount %>
+    <div class="flex flex-wrap gap-3 pt-1">
+      <button type="button"
+              data-ai-input-target="micButton"
+              data-action="click->ai-input#toggleMic"
+              class="flex items-center gap-2 px-4 py-2 bg-white text-indigo-600 border border-indigo-200 rounded-xl text-sm font-medium hover:bg-indigo-50 shadow-sm transition-colors"
+              title="<%= t('ai_input.voice.tap') %>">
+        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-9V3m0 0a3 3 0 00-3 3v4a3 3 0 006 0V6a3 3 0 00-3-3z"/>
+        </svg>
+        <%= t('ai_input.voice.tap') %>
+      </button>
+
+      <label class="flex items-center gap-2 px-4 py-2 bg-white text-slate-600 border border-slate-200 rounded-xl text-sm font-medium hover:bg-slate-50 shadow-sm cursor-pointer transition-colors"
+             title="<%= t('ai_input.camera.tap') %>">
+        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+        </svg>
+        <%= t('ai_input.camera.tap') %>
+        <input type="file" accept="image/jpeg,image/png,image/webp" class="sr-only"
+               data-ai-input-target="fileInput"
+               data-action="change->ai-input#uploadFile">
+      </label>
+    </div>
+    <span data-ai-input-target="statusLabel"
+          class="block mt-1 text-xs text-indigo-600 font-medium min-h-[1rem]"></span>
+  <% end %>
+
+  <!-- Submit -->
   <% if show_submit %>
-    <div class="flex justify-end space-x-3 pt-4">
-      <%= link_to t('form_actions.cancel'), transactions_return_path(return_to), class: "px-6 py-2 border border-slate-300 text-slate-700 rounded-lg font-medium hover:bg-slate-50 transition-colors" %>
-      <%= f.submit t('form_actions.save'), class: "px-6 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors" %>
+    <div class="flex justify-end space-x-3 pt-6 border-t border-slate-100">
+      <%= link_to t('form_actions.cancel'), transactions_return_path(return_to), class: "px-6 py-2.5 border border-slate-200 text-slate-600 rounded-xl font-medium hover:bg-slate-50 transition-colors" %>
+      <%= f.submit t('form_actions.save'), class: "px-6 py-2.5 bg-indigo-600 text-white rounded-xl font-medium hover:bg-indigo-700 transition-colors" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -119,7 +119,7 @@
       </div>
     <% end %>
 
-    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div class="bg-white rounded-2xl shadow-sm ring-1 ring-slate-900/5 p-6 md:p-8">
       <%= render 'transaction_form', transaction: @transaction, bank_accounts: @bank_accounts, return_to: @return_to %>
     </div>
 

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -103,7 +103,7 @@
       </div>
     <% end %>
 
-    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+    <div class="bg-white rounded-2xl shadow-sm ring-1 ring-slate-900/5 p-6 md:p-8">
       <%= render 'transaction_form', transaction: @transaction, bank_accounts: @bank_accounts, return_to: @return_to %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -603,10 +603,10 @@ en:
     select_destination_account: "Select destination account"
     select_source_account_help: "Account to transfer money from"
     select_destination_account_help: "Account to transfer money to"
-    select_bank_account: "Select Bank Account"
+    select_bank_account: "Account"
     select_bank_account_placeholder: "Choose a bank account"
     select_bank_account_help: "Select the bank account for this transaction"
-    transaction_date: "Transaction Date"
+    transaction_date: "Date"
     transaction_date_placeholder: "Select date"
     transaction_description: "Description"
     transaction_description_placeholder: "e.g., Supermarket purchase, Service payment, etc."
@@ -1820,10 +1820,15 @@ en:
     invalid_period: "Invalid year or month."
 
   ai_input:
+    section_title: "Register with AI"
     voice:
-      tap: "Record by voice"
+      tap: "Dictate amount"
     camera:
-      tap: "Scan receipt"
+      tap: "Upload receipt"
+    access_denied:
+      trial_ended: "Your trial has ended. Upgrade to Pro to use AI features."
+      payment_failed: "Payment failed. Update your card to keep access."
+      subscription_required: "AI features are available on the Pro plan."
 
   recurring_suggestions:
     banner_title: "recurring payments detected"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -560,10 +560,10 @@ es:
     create_transaction: "Crear Transacción"
     manual_transaction: "Transacción Manual"
     manual_transaction_description: "Agregar una transacción manualmente sin archivo de estado"
-    select_bank_account: "Seleccionar Cuenta Bancaria"
+    select_bank_account: "Cuenta"
     select_bank_account_placeholder: "Elige una cuenta bancaria"
     select_bank_account_help: "Selecciona la cuenta bancaria para esta transacción"
-    transaction_date: "Fecha de Transacción"
+    transaction_date: "Fecha"
     transaction_date_placeholder: "Selecciona la fecha"
     date_help: "Selecciona la fecha de la transacción"
     transaction_description: "Descripción"
@@ -1810,10 +1810,15 @@ es:
     invalid_period: "Año o mes no válido."
 
   ai_input:
+    section_title: "Registrar con IA"
     voice:
-      tap: "Grabar por voz"
+      tap: "Dictar monto"
     camera:
-      tap: "Escanear recibo"
+      tap: "Subir recibo"
+    access_denied:
+      trial_ended: "Tu período de prueba terminó. Actualiza a Pro para usar las funciones de IA."
+      payment_failed: "No pudimos procesar tu pago. Actualiza tu tarjeta para mantener el acceso."
+      subscription_required: "Las funciones de IA están disponibles en el plan Pro."
 
   recurring_suggestions:
     banner_title: "pagos recurrentes detectados"


### PR DESCRIPTION
- Replace typeChip select with 3-button segmented control (Ingreso/Gasto/Transferencia)
- Add expense/transfer sub-type rows with JS-driven hidden field
- Move AI input buttons (mic + upload) below form with text labels and photo icon
- Change currency prefix from MX$ to $
- Add subscription gating (check_ai_subscription!) for parse_voice and parse_image
- Connect Stimulus controller: new targets, handleTopTypeClick, handleSubTypeClick