### PR TITLE
feat: archive/unarchive bank accounts (fix delete 500)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/app/controllers/api/v1/bank_accounts_controller.rb
+++ b/app/controllers/api/v1/bank_accounts_controller.rb
@@ -3,14 +3,14 @@
 module Api
   module V1
     class BankAccountsController < BaseController
-      before_action :require_confirmed_user!, only: %i[create update destroy]
-      before_action :set_bank_account, only: [:show, :update, :destroy]
+      before_action :require_confirmed_user!, only: %i[create update destroy archive unarchive]
+      before_action :set_bank_account, only: [:show, :update, :destroy, :archive, :unarchive]
 
       # GET /api/v1/bank_accounts
+      # Returns kept accounts by default; pass ?archived=true for archived ones.
       def index
-        @bank_accounts = current_user.bank_accounts
-                                     .includes(:bank)
-                                     .order(:custom_name, :account_number)
+        scope = current_user.bank_accounts.includes(:bank).order(:custom_name, :account_number)
+        @bank_accounts = params[:archived].present? ? scope.discarded : scope.kept
       end
 
       # GET /api/v1/bank_accounts/:id
@@ -47,6 +47,20 @@ module Api
             details: format_validation_errors(@bank_account.errors)
           )
         end
+      end
+
+      # PATCH /api/v1/bank_accounts/:id/archive
+      def archive
+        @bank_account.discard
+        @message = "Bank account archived successfully"
+        render(:show, status: :ok)
+      end
+
+      # PATCH /api/v1/bank_accounts/:id/unarchive
+      def unarchive
+        @bank_account.undiscard
+        @message = "Bank account unarchived successfully"
+        render(:show, status: :ok)
       end
 
       # DELETE /api/v1/bank_accounts/:id

--- a/app/controllers/api/v1/bank_accounts_controller.rb
+++ b/app/controllers/api/v1/bank_accounts_controller.rb
@@ -10,7 +10,7 @@ module Api
       # Returns kept accounts by default; pass ?archived=true for archived ones.
       def index
         scope = current_user.bank_accounts.includes(:bank).order(:custom_name, :account_number)
-        @bank_accounts = params[:archived].present? ? scope.discarded : scope.kept
+        @bank_accounts = params[:archived] == "true" ? scope.discarded : scope.kept
       end
 
       # GET /api/v1/bank_accounts/:id
@@ -51,16 +51,26 @@ module Api
 
       # PATCH /api/v1/bank_accounts/:id/archive
       def archive
-        @bank_account.discard
-        @message = "Bank account archived successfully"
-        render(:show, status: :ok)
+        if @bank_account.discard
+          @message = I18n.t("bank_accounts.archived_successfully")
+          render(:show, status: :ok)
+        else
+          render_error("UNPROCESSABLE", message: I18n.t("bank_accounts.archive_failed"), status: :unprocessable_content)
+        end
       end
 
       # PATCH /api/v1/bank_accounts/:id/unarchive
       def unarchive
-        @bank_account.undiscard
-        @message = "Bank account unarchived successfully"
-        render(:show, status: :ok)
+        if @bank_account.undiscard
+          @message = I18n.t("bank_accounts.unarchived_successfully")
+          render(:show, status: :ok)
+        else
+          render_error(
+            "UNPROCESSABLE",
+            message: I18n.t("bank_accounts.unarchive_failed"),
+            status: :unprocessable_content
+          )
+        end
       end
 
       # DELETE /api/v1/bank_accounts/:id

--- a/app/controllers/bank_accounts_controller.rb
+++ b/app/controllers/bank_accounts_controller.rb
@@ -19,6 +19,8 @@ class BankAccountsController < ApplicationController
 
   def show
     @recent_statement_files = @bank_account.statement_files.order(created_at: :desc).limit(3)
+    @recent_transactions = @bank_account.transactions.includes(:category).order(date: :desc, id: :desc).limit(30)
+    @transactions_count = @bank_account.transactions.count
   end
 
   def new

--- a/app/controllers/bank_accounts_controller.rb
+++ b/app/controllers/bank_accounts_controller.rb
@@ -1,12 +1,13 @@
 # app/controllers/bank_accounts_controller.rb
 class BankAccountsController < ApplicationController
   before_action :authenticate!
-  before_action :require_confirmed_user!, only: %i[create update destroy]
-  before_action :set_bank_account, only: [ :show, :edit, :update, :destroy ]
+  before_action :require_confirmed_user!, only: %i[create update destroy archive unarchive]
+  before_action :set_bank_account, only: [ :show, :edit, :update, :destroy, :archive, :unarchive ]
   before_action :set_supported_banks, only: [ :show, :new, :create, :edit, :update ]
 
   def index
-    @bank_accounts = current_user.bank_accounts.includes(:bank).order(:custom_name, :account_number)
+    @bank_accounts = current_user.bank_accounts.kept.includes(:bank).order(:custom_name, :account_number)
+    @archived_accounts = current_user.bank_accounts.discarded.includes(:bank).order(:custom_name, :account_number)
 
     respond_to do |format|
       format.html
@@ -41,6 +42,16 @@ class BankAccountsController < ApplicationController
     else
       render :edit, status: :unprocessable_content
     end
+  end
+
+  def archive
+    @bank_account.discard
+    redirect_to bank_accounts_path, notice: t("bank_accounts.archived_successfully")
+  end
+
+  def unarchive
+    @bank_account.undiscard
+    redirect_to bank_accounts_path, notice: t("bank_accounts.unarchived_successfully")
   end
 
   def destroy

--- a/app/controllers/bank_accounts_controller.rb
+++ b/app/controllers/bank_accounts_controller.rb
@@ -7,7 +7,9 @@ class BankAccountsController < ApplicationController
 
   def index
     @bank_accounts = current_user.bank_accounts.kept.includes(:bank).order(:custom_name, :account_number)
-    @archived_accounts = current_user.bank_accounts.discarded.includes(:bank).order(:custom_name, :account_number)
+    @archived_accounts = current_user.bank_accounts.discarded
+                                      .includes(:bank, :statement_files, :transactions)
+                                      .order(:custom_name, :account_number)
 
     respond_to do |format|
       format.html
@@ -45,13 +47,19 @@ class BankAccountsController < ApplicationController
   end
 
   def archive
-    @bank_account.discard
-    redirect_to bank_accounts_path, notice: t("bank_accounts.archived_successfully")
+    if @bank_account.discard
+      redirect_to bank_accounts_path, notice: t("bank_accounts.archived_successfully")
+    else
+      redirect_to bank_accounts_path, alert: t("bank_accounts.archive_failed")
+    end
   end
 
   def unarchive
-    @bank_account.undiscard
-    redirect_to bank_accounts_path, notice: t("bank_accounts.unarchived_successfully")
+    if @bank_account.undiscard
+      redirect_to bank_accounts_path, notice: t("bank_accounts.unarchived_successfully")
+    else
+      redirect_to bank_accounts_path, alert: t("bank_accounts.unarchive_failed")
+    end
   end
 
   def destroy

--- a/app/controllers/debts_controller.rb
+++ b/app/controllers/debts_controller.rb
@@ -136,7 +136,7 @@ class DebtsController < ApplicationController
   def load_form_data
     @goals = current_user.goals.debt_payoff_goals.active
     @categories = current_user.categories.hierarchical_order
-    @bank_accounts = current_user.bank_accounts.includes(:bank).order(:custom_name)
+    @bank_accounts = current_user.bank_accounts.kept.includes(:bank).order(:custom_name)
   end
 
   def debt_params

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -56,7 +56,7 @@ class GoalsController < ApplicationController
   def new
     @goal = current_user.goals.new
     @categories = current_user.categories.order(:name)
-    @bank_accounts = current_user.bank_accounts.order(:custom_name)
+    @bank_accounts = current_user.bank_accounts.kept.order(:custom_name)
   end
 
   # POST /goals
@@ -73,7 +73,7 @@ class GoalsController < ApplicationController
         @goal = Goal.new(goal_params)
         @goal.errors.merge!(result.errors)
         @categories = current_user.categories.order(:name)
-        @bank_accounts = current_user.bank_accounts.order(:custom_name)
+        @bank_accounts = current_user.bank_accounts.kept.order(:custom_name)
 
         format.html { render :new, status: :unprocessable_content }
         format.json { render json: @goal.errors, status: :unprocessable_content }
@@ -92,7 +92,7 @@ class GoalsController < ApplicationController
   def edit
     # @goal is set by before_action
     @categories = current_user.categories.order(:name)
-    @bank_accounts = current_user.bank_accounts.order(:custom_name)
+    @bank_accounts = current_user.bank_accounts.kept.order(:custom_name)
   end
 
   # PATCH /goals/:id
@@ -122,7 +122,7 @@ class GoalsController < ApplicationController
       else
         @goal.errors.merge!(result.errors)
         @categories = current_user.categories.order(:name)
-        @bank_accounts = current_user.bank_accounts.order(:custom_name)
+        @bank_accounts = current_user.bank_accounts.kept.order(:custom_name)
 
         format.html { render :edit, status: :unprocessable_content }
         format.json { render json: @goal.errors, status: :unprocessable_content }

--- a/app/controllers/savings_controller.rb
+++ b/app/controllers/savings_controller.rb
@@ -131,7 +131,7 @@ class SavingsController < ApplicationController
   def load_form_data
     @goals = current_user.goals.savings_goals.active
     @categories = current_user.categories.hierarchical_order
-    @bank_accounts = current_user.bank_accounts.includes(:bank).order(:custom_name)
+    @bank_accounts = current_user.bank_accounts.kept.includes(:bank).order(:custom_name)
   end
 
   def saving_params

--- a/app/controllers/statement_files_controller.rb
+++ b/app/controllers/statement_files_controller.rb
@@ -18,7 +18,7 @@ class StatementFilesController < ApplicationController
   def new
     processing_strategy = current_user.user_setting.processing_strategy
     @statement_file = current_user.statement_files.new(processing_strategy: processing_strategy)
-    @bank_accounts = current_user.bank_accounts.joins(:bank).order("banks.name", :account_number)
+    @bank_accounts = current_user.bank_accounts.kept.joins(:bank).order("banks.name", :account_number)
   end
 
   def create
@@ -47,7 +47,7 @@ class StatementFilesController < ApplicationController
         end
       end
     else
-      @bank_accounts = current_user.bank_accounts.joins(:bank).order("banks.name", :account_number)
+      @bank_accounts = current_user.bank_accounts.kept.joins(:bank).order("banks.name", :account_number)
 
       respond_to do |format|
         format.html { render :new, status: :unprocessable_content }

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -443,7 +443,7 @@ image/png image/webp].include?(mime_type)
   end
 
   def load_dropdown_data
-    @bank_accounts = current_user.bank_accounts.left_joins(:bank).order("banks.name NULLS FIRST", :account_number)
+    @bank_accounts = current_user.bank_accounts.kept.left_joins(:bank).order("banks.name NULLS FIRST", :account_number)
     @categories = current_user.categories.where(parent_id: nil).includes(:children).order(:name)
     # Load statement files for dropdown - filter by bank account if one is selected
     if params[:bank_account_id].present?

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -1,4 +1,6 @@
 class BankAccount < ApplicationRecord
+  include Discard::Model
+
   belongs_to :user
   belongs_to :bank, optional: true
   has_many :statement_files, dependent: :destroy

--- a/app/services/assistant/context_assembler.rb
+++ b/app/services/assistant/context_assembler.rb
@@ -29,7 +29,7 @@ module Assistant
       categories     = user.calculate_category_summary(reference_month)
       trends         = user.calculate_spending_trends(reference_month)
 
-      account_count       = user.bank_accounts.count
+      account_count       = user.bank_accounts.kept.count
       has_active_debts    = user.debts.where(status: "active").exists?
       has_active_savings  = user.savings.where(status: "active").exists?
       has_active_goals    = user.goals.where(status: "active").exists?
@@ -68,7 +68,7 @@ module Assistant
         trends: trends.map do |t|
           { month: t[:month], amount: t[:amount].to_f }
         end,
-        accounts: user.bank_accounts.includes(:bank).limit(10).map do |a|
+        accounts: user.bank_accounts.kept.includes(:bank).limit(10).map do |a|
           {
             id: a.id,
             name: a.respond_to?(:custom_name) ? a.custom_name : a.bank&.name,

--- a/app/services/dashboard/data_fetcher.rb
+++ b/app/services/dashboard/data_fetcher.rb
@@ -27,7 +27,7 @@ class Dashboard::DataFetcher < ApplicationService
   attr_reader :selected_month, :user
 
   def aggregate_dashboard_data
-    bank_accounts = user.bank_accounts.includes(:bank, :statement_files, :transactions)
+    bank_accounts = user.bank_accounts.kept.includes(:bank, :statement_files, :transactions)
                         .order("banks.name")
     bank_summaries = calculate_bank_summaries(bank_accounts)
     spending_trends = user.calculate_spending_trends(selected_month)

--- a/app/services/reports/monthly_pdf_generator.rb
+++ b/app/services/reports/monthly_pdf_generator.rb
@@ -65,7 +65,7 @@ module Reports
         .sort_by { |_, total| -total }
         .first(5)
 
-      @bank_accounts = @user.bank_accounts.order(:custom_name)
+      @bank_accounts = @user.bank_accounts.kept.order(:custom_name)
       @savings       = @user.savings.active.order(:name)   rescue []
       @debts         = @user.debts.active.order(:name)     rescue []
 

--- a/app/services/transactions/parse_image_service.rb
+++ b/app/services/transactions/parse_image_service.rb
@@ -55,7 +55,7 @@ class Transactions::ParseImageService < ApplicationService
   end
 
   def user_bank_accounts
-    user.bank_accounts.includes(:bank).map do |a|
+    user.bank_accounts.kept.includes(:bank).map do |a|
       { id: a.id, name: a.display_name, bank: a.bank&.name, type: a.account_type }
     end
   end

--- a/app/services/transactions/parse_voice_service.rb
+++ b/app/services/transactions/parse_voice_service.rb
@@ -35,7 +35,7 @@ class Transactions::ParseVoiceService < ApplicationService
   end
 
   def user_bank_accounts
-    user.bank_accounts.includes(:bank).map do |a|
+    user.bank_accounts.kept.includes(:bank).map do |a|
       { id: a.id, name: a.display_name, bank: a.bank&.name, type: a.account_type }
     end
   end

--- a/app/views/api/v1/shared/_bank_account.json.jbuilder
+++ b/app/views/api/v1/shared/_bank_account.json.jbuilder
@@ -26,3 +26,6 @@ else
 end
 
 json.transactions_count(bank_account.transactions.size)
+
+json.archived(bank_account.discarded?)
+json.archived_at(bank_account.discarded_at)

--- a/app/views/bank_accounts/_mobile_accounts.html.erb
+++ b/app/views/bank_accounts/_mobile_accounts.html.erb
@@ -53,4 +53,28 @@
     <%= icon("circle-plus", library: "lucide", variant: "outline", class: "w-5 h-5 text-indigo-400") %>
     <span class="text-[15px] text-indigo-600 dark:text-indigo-400"><%= t("bank_accounts.add_account") %></span>
   <% end %>
+
+  <% if @archived_accounts.present? && @archived_accounts.any? %>
+    <p class="text-xs font-semibold tracking-widest text-slate-400 uppercase px-5 mt-8 mb-2"><%= t("bank_accounts.archived.title") %></p>
+    <div class="mx-4 bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-hidden">
+      <% @archived_accounts.each_with_index do |bank_account, index| %>
+        <%= link_to bank_account_path(bank_account), class: "mobile-account-row block opacity-60 #{'border-t border-slate-100 dark:border-slate-700' if index.positive?}" do %>
+          <div class="mobile-account-row-icon <%= account_icon_bg_class(bank_account.account_type) %>">
+            <% if bank_account.bank&.logo_url.present? && !bank_account.cash? %>
+              <img src="<%= asset_path(bank_account.bank.logo_url) %>" alt="" class="w-6 h-6 object-contain">
+            <% else %>
+              <%= icon(bank_account.cash? ? "banknote" : "credit-card", library: "lucide", variant: "outline", class: "w-5 h-5") %>
+            <% end %>
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="mobile-account-row-name truncate"><%= bank_account.display_name %></p>
+            <p class="mobile-account-row-meta">
+              <%= t("account_type.#{bank_account.account_type}") %> · <%= bank_account.currency %>
+            </p>
+          </div>
+          <%= icon("chevron-right", library: "lucide", variant: "outline", class: "w-4 h-4 text-slate-300 flex-shrink-0") %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/bank_accounts/index.html.erb
+++ b/app/views/bank_accounts/index.html.erb
@@ -63,22 +63,20 @@
             </span>
 
             <div class="bank-account-actions">
-              <a href="<%= edit_bank_account_path(bank_account) %>" class="bank-account-action-button">
+              <a href="<%= edit_bank_account_path(bank_account) %>" class="bank-account-action-button" title="<%= t('bank_accounts.actions.edit') %>">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                 </svg>
               </a>
-              <%= button_to bank_account_path(bank_account),
-                            method: :delete,
-                            class: "bank-account-action-button bank-account-delete-button",
+              <%= button_to archive_bank_account_path(bank_account),
+                            method: :patch,
+                            class: "bank-account-action-button",
+                            title: t('bank_accounts.actions.archive'),
                             data: {
-                              "turbo-confirm": t('bank_accounts.delete_confirmation',
-                                               account_name: bank_account.display_name,
-                                               statement_files_count: bank_account.statement_files.count,
-                                               transactions_count: bank_account.transactions.count)
+                              "turbo-confirm": t('bank_accounts.archive_confirmation', account_name: bank_account.display_name)
                             } do %>
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
                 </svg>
               <% end %>
             </div>
@@ -116,6 +114,42 @@
           <%= t('bank_accounts.add_first_account') %>
         <% end %>
       </div>
+  <% end %>
+
+  <% if @archived_accounts.any? %>
+    <section class="bank-accounts-archived mt-12">
+      <h2 class="text-lg font-semibold text-slate-500 dark:text-slate-400 mb-4">
+        <%= t('bank_accounts.archived.title') %>
+      </h2>
+      <div class="space-y-3">
+        <% @archived_accounts.each do |bank_account| %>
+          <div class="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 px-4 py-3 opacity-75">
+            <div>
+              <p class="font-medium text-slate-700 dark:text-slate-300"><%= bank_account.display_name %></p>
+              <p class="text-sm text-slate-500 dark:text-slate-400"><%= bank_account.bank_display_name %></p>
+            </div>
+            <div class="flex items-center gap-2">
+              <%= button_to unarchive_bank_account_path(bank_account),
+                            method: :patch,
+                            class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 rounded-md hover:bg-indigo-50 dark:hover:bg-slate-700" do %>
+                <%= t('bank_accounts.actions.unarchive') %>
+              <% end %>
+              <%= button_to bank_account_path(bank_account),
+                            method: :delete,
+                            class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 rounded-md hover:bg-red-50 dark:hover:bg-slate-700",
+                            data: {
+                              "turbo-confirm": t('bank_accounts.delete_confirmation',
+                                               account_name: bank_account.display_name,
+                                               statement_files_count: bank_account.statement_files.count,
+                                               transactions_count: bank_account.transactions.count)
+                            } do %>
+                <%= t('bank_accounts.actions.delete_permanently') %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </section>
   <% end %>
   </div>
 </div>

--- a/app/views/bank_accounts/index.html.erb
+++ b/app/views/bank_accounts/index.html.erb
@@ -140,8 +140,8 @@
                             data: {
                               "turbo-confirm": t('bank_accounts.delete_confirmation',
                                                account_name: bank_account.display_name,
-                                               statement_files_count: bank_account.statement_files.count,
-                                               transactions_count: bank_account.transactions.count)
+                                               statement_files_count: bank_account.statement_files.size,
+                                               transactions_count: bank_account.transactions.size)
                             } do %>
                 <%= t('bank_accounts.actions.delete_permanently') %>
               <% end %>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -323,7 +323,7 @@
                 <span class="text-xs text-slate-400"><%= t('mobile.bank_accounts.n_items', count: txns.size) %></span>
               </div>
               <% txns.each_with_index do |txn, idx| %>
-                <% is_income = txn.income? %>
+                <% is_income = txn.amount > 0 %>
                 <% cat_color = txn.category&.color.presence || (is_income ? "#10b981" : "#6366f1") %>
                 <div class="flex items-center gap-3 px-4 py-3 <%= (group_idx == grouped.size - 1 && idx == txns.size - 1) ? '' : 'border-b border-slate-50 dark:border-slate-700' %>">
                   <!-- Category icon -->

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -56,24 +56,19 @@
     <header class="mobile-bank-account-header">
       <div class="mobile-bank-account-header-content">
         <div class="mobile-bank-account-header-left">
-          <a href="/bank_accounts" class="mobile-back-button">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+          <a href="/bank_accounts" class="mobile-back-button flex items-center gap-1 text-indigo-600 text-sm font-medium">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
             </svg>
+            <%= t('navigation.accounts') %>
           </a>
-          <div class="mobile-bank-account-title-section">
-            <h1 class="mobile-bank-account-title"><%= @bank_account.custom_name %></h1>
-            <div class="flex items-center justify-between">
-              <div class="flex items-center space-x-2">
-                <p class="mobile-bank-account-subtitle"><%= @bank_account.cash? ? t('account_type.cash') : "••••#{@bank_account.account_number.last(4)}" %></p>
-                <% if @bank_account.account_type.present? %>
-                  <span class="text-slate-300">•</span>
-                  <p class="mobile-bank-account-type"><%= t("mobile.bank_accounts.#{@bank_account.account_type}") %></p>
-                <% end %>
-              </div>
-            </div>
-          </div>
         </div>
+        <h1 class="text-base font-semibold text-slate-900 dark:text-slate-100 truncate mx-2"><%= @bank_account.display_name %></h1>
+        <button id="mobileActionsMenuBtn" onclick="openMobileActionsSheet()" class="p-2 text-slate-500 hover:text-slate-700 dark:text-slate-400">
+          <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+            <circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
   </div>
@@ -267,171 +262,185 @@
 
   <!-- MOBILE CONTENT (visible only on mobile) -->
   <div class="block md:hidden">
-    <div class="mobile-bank-account-container">
+    <div class="px-4 pb-24 space-y-4">
 
-      <!-- ACCOUNT BALANCE CARD -->
-      <turbo-frame id="mobile-account-balance" class="mobile-account-balance-frame">
-        <section class="mobile-account-balance-card">
-          <div class="mobile-balance-header">
-            <div class="mobile-balance-icon">
-              <svg class="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 003 3v8a3 3 0 003 3z"></path>
-              </svg>
-            </div>
-            <div class="mobile-balance-info">
-              <h2 class="mobile-balance-title"><%= @bank_account.bank_display_name %></h2>
-              <p class="mobile-balance-subtitle"><%= t('bank_accounts.current_balance') %></p>
-            </div>
-            <div class="mobile-balance-currency">
-              <span class="mobile-currency-badge"><%= @bank_account.currency %></span>
-            </div>
-          </div>
-          <div class="mobile-balance-amount">
-            <% if @bank_account.opening_balance.present? %>
-              <%= number_to_currency(@bank_account.opening_balance, unit: @bank_account.currency || "$") %>
+      <!-- HERO BALANCE CARD -->
+      <div class="bg-white dark:bg-slate-800 rounded-2xl p-4 shadow-sm border border-slate-100 dark:border-slate-700">
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex items-center gap-3">
+            <% if @bank_account.cash? %>
+              <div class="w-10 h-10 bg-emerald-100 dark:bg-emerald-900 rounded-xl flex items-center justify-center">
+                <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                </svg>
+              </div>
+            <% elsif @bank_account.bank&.logo_url.present? %>
+              <img src="<%= asset_path(@bank_account.bank.logo_url) %>" alt="<%= @bank_account.bank.name %>"
+                   class="w-10 h-10 rounded-xl object-contain bg-white border border-slate-100"
+                   onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
+              <div class="w-10 h-10 bg-indigo-100 rounded-xl items-center justify-center hidden">
+                <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 003 3v8a3 3 0 003 3z"></path>
+                </svg>
+              </div>
             <% else %>
-              <%= t('bank_accounts.no_balance_set') %>
-            <% end %>
-          </div>
-        </section>
-      </turbo-frame>
-
-      <!-- QUICK ACTIONS CARD -->
-      <turbo-frame id="mobile-quick-actions" class="mobile-quick-actions-frame">
-        <section class="mobile-quick-actions-card">
-          <h3 class="mobile-card-title"><%= t('quick_actions.title') %></h3>
-          <div class="mobile-actions-grid">
-            <button onclick="openUploadModal()" class="mobile-action-button mobile-action-upload">
-              <div class="mobile-action-icon">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>
+              <div class="w-10 h-10 bg-indigo-100 dark:bg-indigo-900 rounded-xl flex items-center justify-center">
+                <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 003 3v8a3 3 0 003 3z"></path>
                 </svg>
               </div>
-              <div class="mobile-action-content">
-                <span class="mobile-action-title"><%= t('quick_actions.upload_statement') %></span>
-                <span class="mobile-action-subtitle"><%= t('mobile.bank_accounts.upload_help') %></span>
-              </div>
-            </button>
-
-            <button onclick="window.location.href='/transactions?bank_account_id=<%= @bank_account.id %>'" class="mobile-action-button mobile-action-transactions">
-              <div class="mobile-action-icon">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2zm0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                </svg>
-              </div>
-              <div class="mobile-action-content">
-                <span class="mobile-action-title"><%= t('mobile.bank_accounts.view_transactions') %></span>
-                <span class="mobile-action-subtitle"><%= t('mobile.bank_accounts.transactions_help') %></span>
-              </div>
-            </button>
-
-            <button onclick="openBankAccountEditModal()" class="mobile-action-button mobile-action-edit">
-              <div class="mobile-action-icon">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
-                </svg>
-              </div>
-              <div class="mobile-action-content">
-                <span class="mobile-action-title"><%= t('mobile.bank_accounts.edit_account') %></span>
-                <span class="mobile-action-subtitle"><%= t('mobile.bank_accounts.edit_help') %></span>
-              </div>
-            </button>
-
-            <% if @bank_account.discarded? %>
-              <%= button_to unarchive_bank_account_path(@bank_account), method: :patch,
-                    class: "mobile-action-button mobile-action-edit" do %>
-                <div class="mobile-action-icon">
-                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
-                  </svg>
-                </div>
-                <div class="mobile-action-content">
-                  <span class="mobile-action-title"><%= t('bank_accounts.actions.unarchive') %></span>
-                  <span class="mobile-action-subtitle"><%= t('bank_accounts.archived.description') %></span>
-                </div>
-              <% end %>
-            <% else %>
-              <%= button_to archive_bank_account_path(@bank_account), method: :patch,
-                    class: "mobile-action-button mobile-action-edit",
-                    data: { "turbo-confirm": t("bank_accounts.archive_confirmation", account_name: @bank_account.display_name) } do %>
-                <div class="mobile-action-icon">
-                  <svg class="w-6 h-6 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
-                  </svg>
-                </div>
-                <div class="mobile-action-content">
-                  <span class="mobile-action-title"><%= t('bank_accounts.actions.archive') %></span>
-                  <span class="mobile-action-subtitle"><%= t('bank_accounts.archive_help') %></span>
-                </div>
-              <% end %>
             <% end %>
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-slate-100 text-sm leading-tight"><%= @bank_account.display_name %></p>
+              <p class="text-xs text-slate-500 dark:text-slate-400"><%= @bank_account.bank_display_name %></p>
+            </div>
           </div>
-        </section>
-      </turbo-frame>
+          <% if @bank_account.account_type.present? %>
+            <span class="text-xs font-medium px-2.5 py-1 rounded-full bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-200">
+              <%= t("mobile.bank_accounts.#{@bank_account.account_type}") %>
+            </span>
+          <% end %>
+        </div>
+        <% effective_bal = @bank_account.effective_balance %>
+        <p class="text-3xl font-bold tracking-tight <%= effective_bal.to_f < 0 ? 'text-rose-600' : 'text-slate-900 dark:text-slate-100' %>">
+          <%= number_to_currency(effective_bal || 0, unit: "$", delimiter: ",", separator: ".") %>
+        </p>
+        <p class="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          <%= @bank_account.currency %> · <%= @bank_account.account_type.present? ? t("mobile.bank_accounts.#{@bank_account.account_type}") : "" %> · <%= t('mobile.bank_accounts.n_transactions', count: @transactions_count) %>
+        </p>
+      </div>
 
-      <!-- RECENT ACTIVITY CARD -->
-      <turbo-frame id="mobile-recent-activity" class="mobile-recent-activity-frame">
-        <section class="mobile-recent-activity-card">
-          <div class="mobile-card-header">
-            <h3 class="mobile-card-title"><%= t('bank_accounts.recent_activity') %></h3>
-            <% if @recent_statement_files.any? %>
-              <a href="/statement_files" class="mobile-card-link">
-                <%= t('mobile.statement_files.view_all_statements') %>
-              </a>
-            <% end %>
-          </div>
-
-          <% if @recent_statement_files.any? %>
-            <div class="space-y-3">
-              <% @recent_statement_files.each do |statement_file| %>
-                <div class="mobile-statement-file-group">
-                  <!-- Statement File Header -->
-                  <div class="mobile-statement-file-header" onclick="window.location.href='/statement_files/<%= statement_file.id %>'">
-                    <div class="mobile-statement-file-info">
-                      <h3 class="mobile-statement-file-title">
-                        <%= statement_file.file.filename.to_s %>
-                      </h3>
-                      <span class="mobile-statement-file-subtitle">
-                        <%= format_local_time(statement_file.created_at, format: 'short_date') %>
-                      </span>
-                      <div class="mobile-statement-file-status">
-                        <span class="mobile-statement-status-badge <%= statement_file.status == 'completed' ? 'text-green-600' : statement_file.status == 'error' ? 'text-red-600' : 'text-yellow-600' %>">
-                          <%= t("mobile.statement_files.#{statement_file.status}") %>
-                        </span>
-                      </div>
-                    </div>
-                    <div class="mobile-statement-file-right">
-                      <div class="mobile-transactions-info">
-                        <span class="mobile-transactions-count"><%= statement_file.transactions.count %></span>
-                        <span class="mobile-transactions-label"><%= t('mobile.transactions.transactions') %></span>
-                      </div>
-                      <svg class="mobile-statement-chevron h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+      <!-- TRANSACTIONS LIST -->
+      <% grouped = @recent_transactions.group_by(&:date) %>
+      <% if grouped.any? %>
+        <div>
+          <p class="text-xs font-semibold tracking-widest text-slate-400 uppercase px-1 mb-2"><%= t('mobile.transactions.title') %></p>
+          <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-100 dark:border-slate-700 overflow-hidden">
+            <% grouped.each_with_index do |(date, txns), group_idx| %>
+              <!-- Date header -->
+              <div class="flex items-center justify-between px-4 py-2 bg-slate-50 dark:bg-slate-700/50">
+                <span class="text-xs font-medium text-slate-500 dark:text-slate-400"><%= format_local_time(date.to_time, format: 'short_date') rescue date.strftime('%-d %b') %></span>
+                <span class="text-xs text-slate-400"><%= t('mobile.bank_accounts.n_items', count: txns.size) %></span>
+              </div>
+              <% txns.each_with_index do |txn, idx| %>
+                <% is_income = txn.income? %>
+                <% cat_color = txn.category&.color.presence || (is_income ? "#10b981" : "#6366f1") %>
+                <div class="flex items-center gap-3 px-4 py-3 <%= (group_idx == grouped.size - 1 && idx == txns.size - 1) ? '' : 'border-b border-slate-50 dark:border-slate-700' %>">
+                  <!-- Category icon -->
+                  <div class="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                       style="background-color: <%= cat_color %>20;">
+                    <% if txn.category&.icon.present? %>
+                      <span class="text-lg"><%= txn.category.icon %></span>
+                    <% else %>
+                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: <%= cat_color %>">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
                       </svg>
-                    </div>
+                    <% end %>
+                  </div>
+                  <!-- Description + date -->
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium text-slate-900 dark:text-slate-100 truncate"><%= txn.description %></p>
+                    <p class="text-xs text-slate-400"><%= txn.category&.name.presence || t("transaction_types.#{txn.transaction_type}", default: txn.transaction_type.humanize) %></p>
+                  </div>
+                  <!-- Amount + type badge -->
+                  <div class="text-right flex-shrink-0">
+                    <p class="text-sm font-semibold <%= is_income ? 'text-emerald-600' : 'text-rose-600' %>">
+                      <%= is_income ? "+" : "" %><%= number_to_currency(txn.amount.abs, unit: "$", delimiter: ",", separator: ".") %>
+                    </p>
+                    <span class="text-xs px-2 py-0.5 rounded-full font-medium
+                      <%= case txn.transaction_type
+                          when 'income' then 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300'
+                          when 'fixed_expense' then 'bg-amber-50 text-amber-700 dark:bg-amber-900 dark:text-amber-300'
+                          when 'transfer_in', 'transfer_out' then 'bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+                          else 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                          end %>">
+                      <%= t("transaction_types.#{txn.transaction_type}", default: txn.transaction_type.humanize) %>
+                    </span>
                   </div>
                 </div>
               <% end %>
-            </div>
-          <% else %>
-            <div class="mobile-empty-state">
-              <div class="mobile-empty-icon">
-                <svg class="w-12 h-12 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2zm0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                </svg>
-              </div>
-              <h4 class="mobile-empty-title"><%= t('bank_accounts.no_recent_activity') %></h4>
-              <p class="mobile-empty-description"><%= t('bank_accounts.upload_statement_help') %></p>
-              <button onclick="openUploadModal()" class="mobile-empty-action">
-                <%= t('bank_accounts.upload_first_statement') %>
-              </button>
-            </div>
+            <% end %>
+          </div>
+          <% if @transactions_count > 30 %>
+            <a href="/transactions?bank_account_id=<%= @bank_account.id %>"
+               class="mt-3 flex items-center justify-center gap-1 text-sm text-indigo-600 font-medium py-3">
+              <%= t('mobile.bank_accounts.view_all_transactions') %>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+              </svg>
+            </a>
           <% end %>
-        </section>
-      </turbo-frame>
+        </div>
+      <% else %>
+        <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-100 dark:border-slate-700 px-4 py-10 text-center">
+          <div class="w-14 h-14 bg-slate-100 dark:bg-slate-700 rounded-full flex items-center justify-center mx-auto mb-3">
+            <svg class="w-7 h-7 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+            </svg>
+          </div>
+          <p class="text-sm font-medium text-slate-700 dark:text-slate-300"><%= t('bank_accounts.no_recent_activity') %></p>
+          <p class="text-xs text-slate-400 mt-1 mb-4"><%= t('bank_accounts.upload_statement_help') %></p>
+          <button onclick="openUploadModal()" class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-xl">
+            <%= t('bank_accounts.upload_first_statement') %>
+          </button>
+        </div>
+      <% end %>
     </div>
   </div>
 </main>
+
+<!-- MOBILE ACTIONS SHEET (⋯ menu) -->
+<div id="mobileActionsSheet" class="fixed inset-0 z-50 hidden md:hidden" onclick="closeMobileActionsSheet(event)">
+  <div class="absolute inset-0 bg-black/40"></div>
+  <div id="mobileActionsContent" class="absolute bottom-0 left-0 right-0 bg-white dark:bg-slate-800 rounded-t-2xl pb-8 pt-2"
+       style="transform: translateY(100%); transition: transform 250ms ease;">
+    <!-- Handle -->
+    <div class="w-10 h-1 bg-slate-200 dark:bg-slate-600 rounded-full mx-auto mb-4"></div>
+    <!-- Edit -->
+    <button onclick="closeMobileActionsSheet(); openBankAccountEditModal();"
+            class="w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700">
+      <svg class="w-5 h-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+      </svg>
+      <%= t('form_actions.edit') %>
+    </button>
+    <!-- Archive / Unarchive -->
+    <% if @bank_account.discarded? %>
+      <%= button_to unarchive_bank_account_path(@bank_account), method: :patch,
+            class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700" do %>
+        <svg class="w-5 h-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
+        </svg>
+        <%= t('bank_accounts.actions.unarchive') %>
+      <% end %>
+    <% else %>
+      <%= button_to archive_bank_account_path(@bank_account), method: :patch,
+            class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700",
+            data: { "turbo-confirm": t("bank_accounts.archive_confirmation", account_name: @bank_account.display_name) } do %>
+        <svg class="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
+        </svg>
+        <%= t('bank_accounts.actions.archive') %>
+      <% end %>
+    <% end %>
+    <!-- Delete permanently -->
+    <div class="border-t border-slate-100 dark:border-slate-700 mt-2 pt-2">
+      <%= button_to bank_account_path(@bank_account), method: :delete,
+            class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20",
+            data: {
+              "turbo-confirm": t('bank_accounts.delete_confirmation',
+                               account_name: @bank_account.display_name,
+                               statement_files_count: @bank_account.statement_files.size,
+                               transactions_count: @bank_account.transactions.size)
+            } do %>
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+        </svg>
+        <%= t('bank_accounts.actions.delete_permanently') %>
+      <% end %>
+    </div>
+  </div>
+</div>
 
 <!-- MOBILE BANK ACCOUNT EDIT MODAL: Full-Screen Overlay (Mobile Only) -->
 <div id="mobileBankAccountEditModal" class="fixed inset-0 hidden md:hidden" style="z-index: 10000; display: none;">
@@ -602,6 +611,23 @@
 </div>
 
 <script nonce="<%= content_security_policy_nonce %>">
+// Mobile Actions Sheet (⋯ menu)
+function openMobileActionsSheet() {
+  const sheet = document.getElementById('mobileActionsSheet');
+  const content = document.getElementById('mobileActionsContent');
+  if (!sheet || !content) return;
+  sheet.classList.remove('hidden');
+  setTimeout(() => { content.style.transform = 'translateY(0)'; }, 10);
+}
+function closeMobileActionsSheet(event) {
+  if (event && event.target !== event.currentTarget && event.target.id !== 'mobileActionsSheet' && !event.target.classList.contains('bg-black/40')) return;
+  const sheet = document.getElementById('mobileActionsSheet');
+  const content = document.getElementById('mobileActionsContent');
+  if (!sheet || !content) return;
+  content.style.transform = 'translateY(100%)';
+  setTimeout(() => { sheet.classList.add('hidden'); }, 250);
+}
+
 // Bank Account Edit Modal JavaScript Functions
 
 // Track form changes for bank account edit modal

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -324,18 +324,12 @@
               </div>
               <% txns.each_with_index do |txn, idx| %>
                 <% is_income = txn.amount > 0 %>
-                <% cat_color = txn.category&.color.presence || (is_income ? "#10b981" : "#6366f1") %>
+                <% cat_color = txn.category&.color.presence || category_icon_bg_color(txn.category&.icon) %>
                 <div class="flex items-center gap-3 px-4 py-3 <%= (group_idx == grouped.size - 1 && idx == txns.size - 1) ? '' : 'border-b border-slate-50 dark:border-slate-700' %>">
                   <!-- Category icon -->
                   <div class="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
-                       style="background-color: <%= cat_color %>20;">
-                    <% if txn.category&.icon.present? %>
-                      <span class="text-lg"><%= txn.category.icon %></span>
-                    <% else %>
-                      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="color: <%= cat_color %>">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"></path>
-                      </svg>
-                    <% end %>
+                       style="background-color: <%= cat_color %>20; color: <%= cat_color %>;">
+                    <%= icon_svg(txn.category&.icon, css_classes: "w-5 h-5") %>
                   </div>
                   <!-- Description + date -->
                   <div class="flex-1 min-w-0">
@@ -390,10 +384,10 @@
 </main>
 
 <!-- MOBILE ACTIONS SHEET (⋯ menu) -->
-<div id="mobileActionsSheet" class="fixed inset-0 z-50 hidden md:hidden" onclick="closeMobileActionsSheet(event)">
+<div id="mobileActionsSheet" class="fixed inset-0 hidden md:hidden" style="z-index: 10001;" onclick="closeMobileActionsSheet(event)">
   <div class="absolute inset-0 bg-black/40"></div>
-  <div id="mobileActionsContent" class="absolute bottom-0 left-0 right-0 bg-white dark:bg-slate-800 rounded-t-2xl pb-8 pt-2"
-       style="transform: translateY(100%); transition: transform 250ms ease;">
+  <div id="mobileActionsContent" class="absolute bottom-0 left-0 right-0 bg-white dark:bg-slate-800 rounded-t-2xl pt-2"
+       style="transform: translateY(100%); transition: transform 250ms ease; padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);">
     <!-- Handle -->
     <div class="w-10 h-1 bg-slate-200 dark:bg-slate-600 rounded-full mx-auto mb-4"></div>
     <!-- Edit -->
@@ -404,8 +398,8 @@
       </svg>
       <%= t('form_actions.edit') %>
     </button>
-    <!-- Archive / Unarchive -->
     <% if @bank_account.discarded? %>
+      <!-- Unarchive -->
       <%= button_to unarchive_bank_account_path(@bank_account), method: :patch,
             class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700" do %>
         <svg class="w-5 h-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -413,7 +407,24 @@
         </svg>
         <%= t('bank_accounts.actions.unarchive') %>
       <% end %>
+      <!-- Delete permanently (archived only — matches desktop) -->
+      <div class="border-t border-slate-100 dark:border-slate-700 mt-2 pt-2">
+        <%= button_to bank_account_path(@bank_account), method: :delete,
+              class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20",
+              data: {
+                "turbo-confirm": t('bank_accounts.delete_confirmation',
+                                 account_name: @bank_account.display_name,
+                                 statement_files_count: @bank_account.statement_files.size,
+                                 transactions_count: @bank_account.transactions.size)
+              } do %>
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+          </svg>
+          <%= t('bank_accounts.actions.delete_permanently') %>
+        <% end %>
+      </div>
     <% else %>
+      <!-- Archive -->
       <%= button_to archive_bank_account_path(@bank_account), method: :patch,
             class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-slate-900 dark:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-700",
             data: { "turbo-confirm": t("bank_accounts.archive_confirmation", account_name: @bank_account.display_name) } do %>
@@ -423,22 +434,6 @@
         <%= t('bank_accounts.actions.archive') %>
       <% end %>
     <% end %>
-    <!-- Delete permanently -->
-    <div class="border-t border-slate-100 dark:border-slate-700 mt-2 pt-2">
-      <%= button_to bank_account_path(@bank_account), method: :delete,
-            class: "w-full flex items-center gap-4 px-6 py-4 text-left text-base font-medium text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20",
-            data: {
-              "turbo-confirm": t('bank_accounts.delete_confirmation',
-                               account_name: @bank_account.display_name,
-                               statement_files_count: @bank_account.statement_files.size,
-                               transactions_count: @bank_account.transactions.size)
-            } do %>
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-        </svg>
-        <%= t('bank_accounts.actions.delete_permanently') %>
-      <% end %>
-    </div>
   </div>
 </div>
 

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -25,6 +25,18 @@
               </svg>
               <%= t('form_actions.edit') %>
             </a>
+            <% if @bank_account.discarded? %>
+              <%= button_to unarchive_bank_account_path(@bank_account), method: :patch,
+                    class: "bank-accounts-button bank-accounts-button-secondary" do %>
+                <%= t('bank_accounts.actions.unarchive') %>
+              <% end %>
+            <% else %>
+              <%= button_to archive_bank_account_path(@bank_account), method: :patch,
+                    class: "bank-accounts-button bank-accounts-button-secondary",
+                    data: { "turbo-confirm": t("bank_accounts.archive_confirmation", account_name: @bank_account.display_name) } do %>
+                <%= t('bank_accounts.actions.archive') %>
+              <% end %>
+            <% end %>
             <% unless @bank_account.cash? %>
               <a href="/statement_files/new?bank_account_id=<%= @bank_account.id %>" class="bank-accounts-button bank-accounts-button-primary">
                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -324,6 +336,35 @@
                 <span class="mobile-action-subtitle"><%= t('mobile.bank_accounts.edit_help') %></span>
               </div>
             </button>
+
+            <% if @bank_account.discarded? %>
+              <%= button_to unarchive_bank_account_path(@bank_account), method: :patch,
+                    class: "mobile-action-button mobile-action-edit" do %>
+                <div class="mobile-action-icon">
+                  <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
+                  </svg>
+                </div>
+                <div class="mobile-action-content">
+                  <span class="mobile-action-title"><%= t('bank_accounts.actions.unarchive') %></span>
+                  <span class="mobile-action-subtitle"><%= t('bank_accounts.archived.description') %></span>
+                </div>
+              <% end %>
+            <% else %>
+              <%= button_to archive_bank_account_path(@bank_account), method: :patch,
+                    class: "mobile-action-button mobile-action-edit",
+                    data: { "turbo-confirm": t("bank_accounts.archive_confirmation", account_name: @bank_account.display_name) } do %>
+                <div class="mobile-action-icon">
+                  <svg class="w-6 h-6 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"></path>
+                  </svg>
+                </div>
+                <div class="mobile-action-content">
+                  <span class="mobile-action-title"><%= t('bank_accounts.actions.archive') %></span>
+                  <span class="mobile-action-subtitle"><%= t('bank_accounts.archive_help') %></span>
+                </div>
+              <% end %>
+            <% end %>
           </div>
         </section>
       </turbo-frame>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,6 @@
         } catch (e) {}
       })();
     </script>
-    <style>@media (min-width:768px){.desktop-main-content{width:calc(100vw - 18rem) !important}}</style>
   </head>
 
   <body class="bg-slate-50 dark:bg-slate-900 font-sans antialiased" data-controller="profile-sheet sidebar web-push">
@@ -170,7 +169,7 @@
       </aside>
 
       <!-- Main Content Area -->
-      <div class="flex flex-col flex-1 min-h-0 md:ml-72 w-full min-w-0 desktop-main-content">
+      <div class="flex flex-col flex-1 min-h-0 md:ml-72 min-w-0 md:w-[calc(100vw-18rem)]">
         <!-- Mobile Header -->
         <% unless content_for?(:hide_mobile_header) %>
         <header class="mobile-app-header md:hidden">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
         } catch (e) {}
       })();
     </script>
+    <style>@media (min-width:768px){.desktop-main-content{width:calc(100vw - 18rem) !important}}</style>
   </head>
 
   <body class="bg-slate-50 dark:bg-slate-900 font-sans antialiased" data-controller="profile-sheet sidebar web-push">
@@ -169,7 +170,7 @@
       </aside>
 
       <!-- Main Content Area -->
-      <div class="flex flex-col flex-1 min-h-0 md:ml-72 w-full min-w-0">
+      <div class="flex flex-col flex-1 min-h-0 md:ml-72 w-full min-w-0 desktop-main-content">
         <!-- Mobile Header -->
         <% unless content_for?(:hide_mobile_header) %>
         <header class="mobile-app-header md:hidden">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,27 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "1986c1d6444f366e649d3503a26b389169189e021532611f2a83e2223acc8643",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/statements/vision_extractor.rb",
+      "line": 160,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(@gs_cmd, ..., \"-sPDFPassword=#{statement_file.file_password}\", pdf_path)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Statements::VisionExtractor",
+        "method": "convert_pdf_to_images"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [77],
+      "note": "False positive. Open3.capture3 receives a separate argv array, not a shell string — arguments are never passed through /bin/sh, so no shell injection is possible regardless of file_password content. Brakeman flags string interpolation in argv elements as if they were shell-expanded."
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "2674bb6dfbfc3dcc709c88f1c91c892823ef187629ea4d9c834cd2a1d9068366",
@@ -43,6 +64,6 @@
       "note": "False positive. SIGNED_MONTHLY_SQL is built at class-load from the FREQUENCY_DAYS Ruby constant (literal Integer values and a fixed set of String keys). No user input ever reaches the SQL string. Brakeman cannot statically prove constants are safe so it flags the interpolation."
     }
   ],
-  "updated": "2026-05-25",
-  "brakeman_version": "8.0.4"
+  "updated": "2026-06-12",
+  "brakeman_version": "8.0.5"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,8 +347,10 @@ en:
       archive: "Archive"
       unarchive: "Unarchive"
       delete_permanently: "Delete permanently"
+    archive_help: "Hide from balances, keep history"
     archived:
       title: "Archived accounts"
+      description: "Restore this account to your active list"
     added_successfully: "Bank account added"
     updated_successfully: "Updated"
     view_all_statements: "View All Statements"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,7 +339,9 @@ en:
     deleted_successfully: "Bank account deleted successfully"
     archive_confirmation: "Archive '%{account_name}'? It will be hidden from your accounts and balances, but its transaction history is kept. You can unarchive it anytime."
     archived_successfully: "Account archived"
+    archive_failed: "Failed to archive account"
     unarchived_successfully: "Account unarchived"
+    unarchive_failed: "Failed to unarchive account"
     actions:
       edit: "Edit"
       archive: "Archive"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,16 @@ en:
     delete_account: "Delete Account"
     delete_confirmation: "Are you sure you want to delete the account '%{account_name}'? This will permanently delete %{statement_files_count} statement files and %{transactions_count} transactions. This action cannot be undone."
     deleted_successfully: "Bank account deleted successfully"
+    archive_confirmation: "Archive '%{account_name}'? It will be hidden from your accounts and balances, but its transaction history is kept. You can unarchive it anytime."
+    archived_successfully: "Account archived"
+    unarchived_successfully: "Account unarchived"
+    actions:
+      edit: "Edit"
+      archive: "Archive"
+      unarchive: "Unarchive"
+      delete_permanently: "Delete permanently"
+    archived:
+      title: "Archived accounts"
     added_successfully: "Bank account added"
     updated_successfully: "Updated"
     view_all_statements: "View All Statements"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,13 @@ en:
       debit: "Debit"
       cash: "Cash"
       statements: "statements"
+      n_transactions:
+        one: "1 transaction"
+        other: "%{count} transactions"
+      n_items:
+        one: "1 item"
+        other: "%{count} items"
+      view_all_transactions: "View all transactions"
     statement_files:
       your_files: "Your Files"
       total_files: "Total Files"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -324,8 +324,10 @@ es:
       archive: "Archivar"
       unarchive: "Desarchivar"
       delete_permanently: "Eliminar permanentemente"
+    archive_help: "Ocultar de balances, conservar historial"
     archived:
       title: "Cuentas archivadas"
+      description: "Restaurar esta cuenta a tu lista activa"
     added_successfully: "Cuenta bancaria agregada"
     updated_successfully: "Actualizado"
     view_all_statements: "Ver Todos los Estados de Cuenta"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -314,6 +314,16 @@ es:
     delete_account: "Eliminar Cuenta"
     delete_confirmation: "¿Estás seguro de que quieres eliminar la cuenta '%{account_name}'? Esto eliminará permanentemente %{statement_files_count} archivos de estado y %{transactions_count} transacciones. Esta acción no se puede deshacer."
     deleted_successfully: "Cuenta bancaria eliminada exitosamente"
+    archive_confirmation: "¿Archivar '%{account_name}'? Se ocultará de tus cuentas y balances, pero se conserva su historial de transacciones. Puedes desarchivarla cuando quieras."
+    archived_successfully: "Cuenta archivada"
+    unarchived_successfully: "Cuenta desarchivada"
+    actions:
+      edit: "Editar"
+      archive: "Archivar"
+      unarchive: "Desarchivar"
+      delete_permanently: "Eliminar permanentemente"
+    archived:
+      title: "Cuentas archivadas"
     added_successfully: "Cuenta bancaria agregada"
     updated_successfully: "Actualizado"
     view_all_statements: "Ver Todos los Estados de Cuenta"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -316,7 +316,9 @@ es:
     deleted_successfully: "Cuenta bancaria eliminada exitosamente"
     archive_confirmation: "¿Archivar '%{account_name}'? Se ocultará de tus cuentas y balances, pero se conserva su historial de transacciones. Puedes desarchivarla cuando quieras."
     archived_successfully: "Cuenta archivada"
+    archive_failed: "Error al archivar la cuenta"
     unarchived_successfully: "Cuenta desarchivada"
+    unarchive_failed: "Error al desarchivar la cuenta"
     actions:
       edit: "Editar"
       archive: "Archivar"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -205,6 +205,13 @@ es:
       debit: "Débito"
       cash: "Efectivo"
       statements: "estados de cuenta"
+      n_transactions:
+        one: "1 transacción"
+        other: "%{count} transacciones"
+      n_items:
+        one: "1 elemento"
+        other: "%{count} elementos"
+      view_all_transactions: "Ver todas las transacciones"
     statement_files:
       your_files: "Tus Archivos"
       total_files: "Total de Archivos"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,10 @@ Rails.application.routes.draw do
   get "/finances", to: "finances#index", as: :finances
 
   resources :bank_accounts do
+    member do
+      patch :archive
+      patch :unarchive
+    end
     resources :statement_files, only: [:index], controller: "bank_accounts/statement_files"
   end
   resources :categories
@@ -184,7 +188,12 @@ Rails.application.routes.draw do
       resources :categories, only: [:index, :show, :create, :update, :destroy]
 
       # Bank Accounts
-      resources :bank_accounts, only: [:index, :show, :create, :update, :destroy]
+      resources :bank_accounts, only: [:index, :show, :create, :update, :destroy] do
+        member do
+          patch :archive
+          patch :unarchive
+        end
+      end
 
       # Savings
       resources :savings, only: [:index, :show, :create, :update, :destroy] do

--- a/db/migrate/20260611014626_add_discarded_at_to_bank_accounts.rb
+++ b/db/migrate/20260611014626_add_discarded_at_to_bank_accounts.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToBankAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :bank_accounts, :discarded_at, :datetime
+    add_index :bank_accounts, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_04_055739) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_11_014626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -93,8 +93,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_04_055739) do
     t.string "custom_name", limit: 100
     t.date "opening_balance_date", default: -> { "CURRENT_DATE" }, null: false
     t.string "account_type", default: "debit", null: false
+    t.datetime "discarded_at"
     t.index ["account_type"], name: "index_bank_accounts_on_account_type"
     t.index ["bank_id"], name: "index_bank_accounts_on_bank_id"
+    t.index ["discarded_at"], name: "index_bank_accounts_on_discarded_at"
     t.index ["opening_balance_date"], name: "index_bank_accounts_on_opening_balance_date"
     t.index ["user_id", "bank_id", "account_number"], name: "index_bank_accounts_on_user_bank_account_number_unique", unique: true, where: "((account_type)::text <> 'cash'::text)"
     t.index ["user_id"], name: "index_bank_accounts_on_user_id"

--- a/spec/integration/api/v1/bank_accounts/archive_spec.rb
+++ b/spec/integration/api/v1/bank_accounts/archive_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe("API V1 Bank Accounts - Archive/Unarchive", type: :request) do
       tags("Bank Accounts")
       produces("application/json")
       security([Bearer: []])
-      description("Soft-delete a bank account using discard. The account is hidden from lists and balance totals but its transaction history is preserved. Can be restored with unarchive.")
+      description(
+        "Soft-delete a bank account using discard. The account is hidden from lists and balance " \
+        "totals but its transaction history is preserved. Can be restored with unarchive."
+      )
 
       response("200", "Bank account archived successfully") do
         schema("$ref" => "#/components/schemas/v1_bank_account_single_response")

--- a/spec/integration/api/v1/bank_accounts/archive_spec.rb
+++ b/spec/integration/api/v1/bank_accounts/archive_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe("API V1 Bank Accounts - Archive/Unarchive", type: :request) do
+  path("/api/v1/bank_accounts/{id}/archive") do
+    parameter(name: :id, in: :path, type: :integer, description: "Bank Account ID")
+
+    patch("Archive a bank account") do
+      tags("Bank Accounts")
+      produces("application/json")
+      security([Bearer: []])
+      description("Soft-delete a bank account using discard. The account is hidden from lists and balance totals but its transaction history is preserved. Can be restored with unarchive.")
+
+      response("200", "Bank account archived successfully") do
+        schema("$ref" => "#/components/schemas/v1_bank_account_single_response")
+
+        let(:user) { create(:user) }
+        let(:Authorization) { "Bearer #{Auth::GenerateTokensService.call(user).payload[:access_token]}" }
+        let(:bank) { create(:bank, name: "Test Bank", code: "test") }
+        let(:bank_account_record) { create(:bank_account, user: user, bank: bank) }
+        let(:id) { bank_account_record.id }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["data"]["archived"]).to be true
+          expect(data["data"]["archived_at"]).to be_present
+        end
+      end
+
+      response("404", "Bank account not found") do
+        schema("$ref" => "#/components/schemas/error_response")
+
+        let(:user) { create(:user) }
+        let(:Authorization) { "Bearer #{Auth::GenerateTokensService.call(user).payload[:access_token]}" }
+        let(:id) { 999999 }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["error"]["code"]).to eq("NOT_FOUND")
+        end
+      end
+
+      response("401", "Unauthorized - Invalid or missing token") do
+        schema("$ref" => "#/components/schemas/error_response")
+
+        let(:Authorization) { "Bearer invalid.token" }
+        let(:id) { 1 }
+
+        run_test!
+      end
+    end
+  end
+
+  path("/api/v1/bank_accounts/{id}/unarchive") do
+    parameter(name: :id, in: :path, type: :integer, description: "Bank Account ID")
+
+    patch("Unarchive a bank account") do
+      tags("Bank Accounts")
+      produces("application/json")
+      security([Bearer: []])
+      description("Restore a previously archived bank account. The account will reappear in lists and balance totals.")
+
+      response("200", "Bank account unarchived successfully") do
+        schema("$ref" => "#/components/schemas/v1_bank_account_single_response")
+
+        let(:user) { create(:user) }
+        let(:Authorization) { "Bearer #{Auth::GenerateTokensService.call(user).payload[:access_token]}" }
+        let(:bank) { create(:bank, name: "Test Bank", code: "test") }
+        let(:bank_account_record) { create(:bank_account, user: user, bank: bank, discarded_at: Time.current) }
+        let(:id) { bank_account_record.id }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["data"]["archived"]).to be false
+          expect(data["data"]["archived_at"]).to be_nil
+        end
+      end
+
+      response("404", "Bank account not found") do
+        schema("$ref" => "#/components/schemas/error_response")
+
+        let(:user) { create(:user) }
+        let(:Authorization) { "Bearer #{Auth::GenerateTokensService.call(user).payload[:access_token]}" }
+        let(:id) { 999999 }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["error"]["code"]).to eq("NOT_FOUND")
+        end
+      end
+
+      response("401", "Unauthorized - Invalid or missing token") do
+        schema("$ref" => "#/components/schemas/error_response")
+
+        let(:Authorization) { "Bearer invalid.token" }
+        let(:id) { 1 }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -476,4 +476,33 @@ RSpec.describe BankAccount, type: :model do
       end
     end
   end
+
+  describe "discard (archive) behaviour" do
+    let!(:persisted_account) { create(:bank_account, bank: bank, user: user) }
+
+    it "sets discarded_at on discard" do
+      expect { persisted_account.discard }.to change { persisted_account.discarded_at }.from(nil)
+      expect(persisted_account).to be_discarded
+    end
+
+    it "clears discarded_at on undiscard" do
+      persisted_account.discard
+      expect { persisted_account.undiscard }.to change { persisted_account.discarded_at }.to(nil)
+      expect(persisted_account).not_to be_discarded
+    end
+
+    it ".kept excludes discarded accounts" do
+      persisted_account.discard
+      expect(BankAccount.kept).not_to include(persisted_account)
+    end
+
+    it ".kept includes non-discarded accounts" do
+      expect(BankAccount.kept).to include(persisted_account)
+    end
+
+    it ".discarded returns only discarded accounts" do
+      persisted_account.discard
+      expect(BankAccount.discarded).to include(persisted_account)
+    end
+  end
 end

--- a/spec/requests/api/v1/bank_accounts/archive_spec.rb
+++ b/spec/requests/api/v1/bank_accounts/archive_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe "Api::V1::BankAccounts - Archive/Unarchive", type: :request do
 
   describe "GET /api/v1/bank_accounts - archived filtering" do
     let!(:kept_account) { create(:bank_account, user: user, bank: bank, custom_name: "Active") }
-    let!(:discarded_account) { create(:bank_account, user: user, bank: bank, custom_name: "Archived", discarded_at: Time.current) }
+    let!(:discarded_account) do
+      create(:bank_account, user: user, bank: bank, custom_name: "Archived", discarded_at: Time.current)
+    end
 
     it "excludes archived accounts by default" do
       get "/api/v1/bank_accounts", headers: auth_headers

--- a/spec/requests/api/v1/bank_accounts/archive_spec.rb
+++ b/spec/requests/api/v1/bank_accounts/archive_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::BankAccounts - Archive/Unarchive", type: :request do
+  let(:user) { create(:user) }
+  let(:auth_headers) { { "Authorization" => "Bearer #{Auth::GenerateTokensService.call(user).payload[:access_token]}" } }
+  let(:bank) { create(:bank, name: "Test Bank", code: "test") }
+  let(:bank_account) { create(:bank_account, user: user, bank: bank) }
+
+  describe "PATCH /api/v1/bank_accounts/:id/archive" do
+    it "archives the bank account" do
+      patch "/api/v1/bank_accounts/#{bank_account.id}/archive", headers: auth_headers
+      json = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(json["data"]["archived"]).to be true
+      expect(json["data"]["archived_at"]).to be_present
+      expect(bank_account.reload).to be_discarded
+    end
+
+    it "returns 404 for another user's bank account" do
+      other_user = create(:user)
+      other_account = create(:bank_account, user: other_user, bank: bank)
+
+      patch "/api/v1/bank_accounts/#{other_account.id}/archive", headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 for non-existent bank account" do
+      patch "/api/v1/bank_accounts/999999/archive", headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 401 when not authenticated" do
+      patch "/api/v1/bank_accounts/#{bank_account.id}/archive"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "PATCH /api/v1/bank_accounts/:id/unarchive" do
+    let!(:archived_account) { create(:bank_account, user: user, bank: bank, discarded_at: Time.current) }
+
+    it "unarchives the bank account" do
+      patch "/api/v1/bank_accounts/#{archived_account.id}/unarchive", headers: auth_headers
+      json = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(json["data"]["archived"]).to be false
+      expect(json["data"]["archived_at"]).to be_nil
+      expect(archived_account.reload).to be_undiscarded
+    end
+
+    it "returns 404 for another user's bank account" do
+      other_user = create(:user)
+      other_account = create(:bank_account, user: other_user, bank: bank, discarded_at: Time.current)
+
+      patch "/api/v1/bank_accounts/#{other_account.id}/unarchive", headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 401 when not authenticated" do
+      patch "/api/v1/bank_accounts/#{archived_account.id}/unarchive"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/v1/bank_accounts - archived filtering" do
+    let!(:kept_account) { create(:bank_account, user: user, bank: bank, custom_name: "Active") }
+    let!(:discarded_account) { create(:bank_account, user: user, bank: bank, custom_name: "Archived", discarded_at: Time.current) }
+
+    it "excludes archived accounts by default" do
+      get "/api/v1/bank_accounts", headers: auth_headers
+      json = JSON.parse(response.body)
+
+      ids = json["data"]["bank_accounts"].map { |a| a["id"] }
+      expect(ids).to include(kept_account.id)
+      expect(ids).not_to include(discarded_account.id)
+    end
+
+    it "returns only archived accounts with ?archived=true" do
+      get "/api/v1/bank_accounts", params: { archived: true }, headers: auth_headers
+      json = JSON.parse(response.body)
+
+      ids = json["data"]["bank_accounts"].map { |a| a["id"] }
+      expect(ids).not_to include(kept_account.id)
+      expect(ids).to include(discarded_account.id)
+    end
+
+    it "includes archived field in response" do
+      get "/api/v1/bank_accounts", headers: auth_headers
+      json = JSON.parse(response.body)
+
+      account = json["data"]["bank_accounts"].find { |a| a["id"] == kept_account.id }
+      expect(account).to have_key("archived")
+      expect(account["archived"]).to be false
+    end
+  end
+end

--- a/spec/requests/bank_accounts_spec.rb
+++ b/spec/requests/bank_accounts_spec.rb
@@ -173,4 +173,38 @@ RSpec.describe "BankAccounts", type: :request do
       expect(response).to redirect_to("/bank_accounts")
     end
   end
+
+  describe "PATCH /bank_accounts/:id/archive" do
+    let!(:bank_account) { create(:bank_account, user: user, bank: bbva_bank) }
+
+    it "archives the account without deleting it" do
+      expect {
+        patch "/bank_accounts/#{bank_account.id}/archive"
+      }.not_to change(BankAccount, :count)
+
+      expect(bank_account.reload).to be_discarded
+      expect(response).to redirect_to("/bank_accounts")
+    end
+
+    it "hides archived accounts from the active list but shows them in the archived section" do
+      patch "/bank_accounts/#{bank_account.id}/archive"
+      get "/bank_accounts"
+
+      # Active section should not include the archived account's unarchive path
+      # Archived section should include the unarchive path for this account
+      expect(response.body).to include(unarchive_bank_account_path(bank_account))
+      expect(response.body).not_to include(archive_bank_account_path(bank_account))
+    end
+  end
+
+  describe "PATCH /bank_accounts/:id/unarchive" do
+    let!(:bank_account) { create(:bank_account, user: user, bank: bbva_bank, discarded_at: Time.current) }
+
+    it "restores an archived account" do
+      patch "/bank_accounts/#{bank_account.id}/unarchive"
+
+      expect(bank_account.reload).to be_undiscarded
+      expect(response).to redirect_to("/bank_accounts")
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -183,6 +183,77 @@ paths:
                   password: password123
                   first_name: John
                   last_name: Doe
+  "/api/v1/bank_accounts/{id}/archive":
+    parameters:
+    - name: id
+      in: path
+      description: Bank Account ID
+      required: true
+      schema:
+        type: integer
+    patch:
+      summary: Archive a bank account
+      tags:
+      - Bank Accounts
+      security:
+      - Bearer: []
+      description: Soft-delete a bank account using discard. The account is hidden
+        from lists and balance totals but its transaction history is preserved. Can
+        be restored with unarchive.
+      responses:
+        '200':
+          description: Bank account archived successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/v1_bank_account_single_response"
+        '404':
+          description: Bank account not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_response"
+        '401':
+          description: Unauthorized - Invalid or missing token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_response"
+  "/api/v1/bank_accounts/{id}/unarchive":
+    parameters:
+    - name: id
+      in: path
+      description: Bank Account ID
+      required: true
+      schema:
+        type: integer
+    patch:
+      summary: Unarchive a bank account
+      tags:
+      - Bank Accounts
+      security:
+      - Bearer: []
+      description: Restore a previously archived bank account. The account will reappear
+        in lists and balance totals.
+      responses:
+        '200':
+          description: Bank account unarchived successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/v1_bank_account_single_response"
+        '404':
+          description: Bank account not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_response"
+        '401':
+          description: Unauthorized - Invalid or missing token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_response"
   "/api/v1/bank_accounts":
     post:
       summary: Create a new bank account
@@ -521,10 +592,15 @@ paths:
               schema:
                 type: object
                 properties:
-                  message:
-                    type: string
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                    required:
+                    - message
                 required:
-                - message
+                - data
         '422':
           description: Cannot delete category with subcategories
           content:


### PR DESCRIPTION
## Summary

- Fixes 500 error on bank account deletion by making archive the primary action (permanent delete is a two-step escape hatch in the archived section)
- Adds `discarded_at` column via `discard` gem to soft-delete bank accounts
- Archived accounts are hidden from lists, balance totals, and pickers — but transaction history is preserved
- Web UI: active cards have Archive only; archived section shows Unarchive + Delete permanently
- API: `PATCH /api/v1/bank_accounts/:id/archive` and `/unarchive` endpoints; `GET` index supports `?archived=true`
- Fixes global desktop layout overflow (content clipped to the right)

## Test plan

- [ ] `bundle exec rspec spec/models/bank_account_spec.rb spec/requests/bank_accounts_spec.rb spec/requests/api/v1/bank_accounts/archive_spec.rb spec/integration/api/v1/bank_accounts/archive_spec.rb` → 0 failures
- [ ] Visit `/bank_accounts` → archive an active account → it moves to archived section, dashboard balance drops
- [ ] Unarchive → account returns to active list
- [ ] Delete permanently from archived section → account and all data gone, no 500
- [ ] All pages render without right-side overflow on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)