### PR TITLE
Address PR review: locale util, float precision, currency style, hard…

### DIFF
--- a/app/javascript/controllers/balance_count_up_controller.js
+++ b/app/javascript/controllers/balance_count_up_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { resolveLocale } from "./utils/locale"
 
 export default class extends Controller {
   static values = { amount: Number, duration: { type: Number, default: 800 } }
@@ -28,7 +29,7 @@ export default class extends Controller {
   }
 
   format(value) {
-    const locale = document.documentElement.lang === "es" ? "es-MX" : "en-US"
+    const locale = resolveLocale()
     return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "MXN",

--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { resolveLocale } from "./utils/locale"
 
 // Infinite scroll controller for the transactions index.
 // Reads pagination state and filter params from data attributes on the
@@ -149,8 +150,8 @@ export default class extends Controller {
           if (targetCard && incomingCard) {
             incomingCard.querySelectorAll(".mobile-tx-row").forEach(row => targetCard.appendChild(row))
           }
-          const newTotal = parseFloat(existing.dataset.dayTotal || "0") + parseFloat(group.dataset.dayTotal || "0")
-          existing.dataset.dayTotal = newTotal
+          const newTotal = Math.round((parseFloat(existing.dataset.dayTotal || "0") + parseFloat(group.dataset.dayTotal || "0")) * 100) / 100
+          existing.dataset.dayTotal = String(newTotal)
           this.updateDayTotal(existing, newTotal)
         } else {
           mobileList.appendChild(group)
@@ -163,12 +164,13 @@ export default class extends Controller {
   updateDayTotal(group, total) {
     const span = group.querySelector(".mobile-date-section-header span:last-child")
     if (!span) return
-    const locale = document.documentElement.lang === "es" ? "es-MX" : "en-US"
-    const amount = new Intl.NumberFormat(locale, {
+    const formatted = new Intl.NumberFormat(resolveLocale(), {
+      style: "currency",
+      currency: "MXN",
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     }).format(Math.abs(total))
-    span.textContent = `${total >= 0 ? "+" : "-"}$${amount}`
+    span.textContent = `${total >= 0 ? "+" : "-"}${formatted}`
     span.classList.toggle("money-positive", total >= 0)
     span.classList.toggle("money-negative", total < 0)
   }

--- a/app/javascript/controllers/utils/locale.js
+++ b/app/javascript/controllers/utils/locale.js
@@ -1,0 +1,5 @@
+// Maps the HTML lang attribute to an Intl-compatible locale.
+// "es" is Spain (European format); MXN amounts use "es-MX".
+export function resolveLocale() {
+  return document.documentElement.lang === "es" ? "es-MX" : "en-US"
+}

--- a/e2e/tests/mobile-web.spec.ts
+++ b/e2e/tests/mobile-web.spec.ts
@@ -445,11 +445,10 @@ test.describe("mobile web parity (<768px)", () => {
       const mobileList = page.locator("[data-mobile-transactions-list]");
       await expect(mobileList).toBeVisible();
 
+      // Seed data must produce >20 transactions so pagination fires.
+      // If the trigger is absent the seed is broken, not a skip condition.
       const scrollTrigger = page.locator(".scroll-trigger").first();
-      if (!(await scrollTrigger.isVisible())) {
-        test.skip(true, "not enough seed transactions to trigger pagination");
-        return;
-      }
+      await expect(scrollTrigger).toBeVisible({ timeout: 5_000 });
 
       const initialRows = await mobileList.locator(".mobile-tx-row").count();
       expect(initialRows).toBeGreaterThan(0);


### PR DESCRIPTION
…en e2e

- Extract locale detection to controllers/utils/locale.js and import in both balance_count_up and infinite_scroll controllers to eliminate drift
- Fix float arithmetic in day-total merge: Math.round(…* 100) / 100 avoids IEEE 754 accumulation errors (0.1 + 0.2 != 0.3)
- Switch updateDayTotal to style:"currency"/currency:"MXN" so the symbol comes from Intl instead of a hardcoded $ literal
- Replace silent test.skip in infinite-scroll e2e with a hard assertion so a seed-data regression fails loudly