### PR TITLE
SEO: add Organization schema, fix social meta, refresh llms.txt

### DIFF
--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -13,6 +13,7 @@
     <% base_url = request.original_url.split("?").first %>
     <% canonical_url = lang == "en" ? "#{base_url}?locale=en" : base_url %>
     <% og_image = "#{request.protocol}#{request.host_with_port}/vittio_new_with_description.jpg" %>
+    <% og_image_alt = lang == "en" ? "Vittio — personal finance dashboard for Mexico" : "Vittio — panel de finanzas personales para México" %>
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -33,13 +34,14 @@
     <meta property="og:image" content="<%= og_image %>">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="<%= og_image_alt %>">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@VittioMX">
     <meta name="twitter:title" content="<%= page_title %>">
     <meta name="twitter:description" content="<%= page_description %>">
     <meta name="twitter:image" content="<%= og_image %>">
+    <meta name="twitter:image:alt" content="<%= og_image_alt %>">
 
     <!-- hreflang -->
     <link rel="alternate" hreflang="es" href="<%= base_url %>">
@@ -60,6 +62,17 @@
 
     <script type="application/ld+json">
     {"@context":"https://schema.org","@type":"WebSite","name":"Vittio","url":"https://vitt.io"}
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Vittio",
+      "url": "https://vitt.io",
+      "logo": "https://vitt.io/icon.png",
+      "email": "hola@vitt.io",
+      "sameAs": ["https://www.instagram.com/vittio.mx/"]
+    }
     </script>
 
     <%= yield :head %>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,16 +4,16 @@
 
 ## What it is
 
-- **Product**: Web app + planned iOS/Android (React Native) for personal finance management.
+- **Product**: Web app (live now) with native iOS/Android (React Native) arriving August 2026, for personal finance management.
 - **Core flow**: User uploads a bank statement PDF → Vittio parses and categorizes every transaction → user sees a real-time dashboard with balances, expenses by category, savings progress and debt tracking.
 - **Differentiator**: No bank credentials are required. Vittio never connects to online banking. It only processes the PDF the user uploads.
 - **Audience**: Mexican consumers who want to understand and control their personal finances. Primary language: Spanish (es-MX). Currency: MXN.
-- **Status**: Pre-launch. Waitlist open. Launch planned in 2026.
-- **Pricing model (planned)**: Free tier + Premium tier. Statement upload, voice entry and photo-receipt features will be Premium. Manual transaction entry, categorization and dashboard will remain free.
+- **Status**: Live. The web app is available now at https://app.vitt.io — sign up free, no credit card. Native iOS and Android apps arrive August 2026.
+- **Pricing model**: Free forever tier + Premium ($149 MXN/month, or $99/month billed annually). New accounts get 30 days of Premium free, no card required. Statement/CSV import with AI, voice entry, photo-receipt capture and auto-categorization are Premium. Manual transaction entry, categorization and dashboard are free.
 
 ## Supported banks
 
-BBVA, Banorte, Santander, HSBC, Scotiabank, Citibanamex, Nu, Rappi — and most other Mexican banks via AI vision processing.
+Banorte, BBVA, Santander, Citibanamex, HSBC, Scotiabank, Nu, Hey Banco, Klar, Albo, Inbursa, Banco Azteca — and most other Mexican banks via AI vision processing.
 
 ## Features
 
@@ -27,7 +27,8 @@ BBVA, Banorte, Santander, HSBC, Scotiabank, Citibanamex, Nu, Rappi — and most 
 
 ## Pages
 
-- [Landing page](https://vitt.io/) — product overview + waitlist signup
+- [Landing page](https://vitt.io/) — product overview + free signup
+- [Pricing](https://vitt.io/pricing) — Free and Premium plans
 - [Privacy policy](https://vitt.io/legal/privacy)
 - [Terms of service](https://vitt.io/legal/terms)
 - [Financial data handling](https://vitt.io/legal/financial_data)


### PR DESCRIPTION
- Add Organization JSON-LD (logo, email, real Instagram sameAs) to feed brand knowledge panel and AI-search citations
- Remove non-existent @VittioMX twitter:site handle; summary_large_image card works without it
- Add og:image:alt and twitter:image:alt (localized ES/EN)
- Update public/llms.txt stale "pre-launch/waitlist" status to live web app + real Premium pricing; align bank list and add /pricing page