### PR TITLE
Fix mobile landing page: center hero CTA, stop bank marquee overflow

### DIFF
--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -80,7 +80,7 @@
 
 *, *::before, *::after { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
-html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; overflow-x: clip; }
 body {
   font-family: var(--font-sans);
   font-size: 16px;
@@ -468,7 +468,7 @@ body.theme-light .hero-cursor-glow {
   align-items: center;
 }
 @media (max-width: 980px) {
-  .hero-grid { grid-template-columns: 1fr; gap: 48px; }
+  .hero-grid { grid-template-columns: minmax(0, 1fr); gap: 48px; }
   .hero { padding: 110px 0 60px; }
 }
 
@@ -531,6 +531,7 @@ body.theme-light .hero-sub { color: var(--slate-600); }
   border: 1px solid rgba(255,255,255,.18);
   backdrop-filter: blur(20px);
   border-radius: 999px;
+  width: 100%;
   max-width: 480px;
   transition: border-color .2s, background .2s;
 }
@@ -798,10 +799,10 @@ body.theme-light .hero-trust-row svg { color: var(--indigo-500); }
 }
 
 @media (max-width: 720px) {
-  .trust-inner { flex-direction: column; align-items: flex-start; gap: 14px; }
+  .trust-inner { flex-direction: column; align-items: flex-start; gap: 14px; max-width: 100%; }
   /* align-items:flex-start above stops .marquee from stretching, so it
      sizes to the unrolled track's full width and overflows the viewport. */
-  .marquee { width: 100%; min-width: 0; align-self: stretch; }
+  .marquee { width: 100%; max-width: 100%; min-width: 0; align-self: stretch; }
 }
 
 /* ============================================================

--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -718,10 +718,13 @@ body.theme-light .hero-trust-row svg { color: var(--indigo-500); }
   .hero-screen-desktop { display: none; }
   .hero-phone { display: block; }
   .float-balance, .float-tx { display: none; }
-  .hero-form { padding: 5px; }
+  .hero-copy { text-align: center; }
+  .hero-eyebrow { display: flex; justify-content: center; }
+  .hero-sub { margin-inline: auto; }
+  .hero-form { padding: 5px; margin: 0 auto; }
   .hero-form input { padding: 11px 14px; font-size: 14px; }
   .hero-form button { padding: 11px 18px; }
-  .hero-trust-row { gap: 12px; font-size: 12px; }
+  .hero-trust-row { gap: 12px; font-size: 12px; justify-content: center; }
 }
 
 /* ============================================================
@@ -796,6 +799,9 @@ body.theme-light .hero-trust-row svg { color: var(--indigo-500); }
 
 @media (max-width: 720px) {
   .trust-inner { flex-direction: column; align-items: flex-start; gap: 14px; }
+  /* align-items:flex-start above stops .marquee from stretching, so it
+     sizes to the unrolled track's full width and overflows the viewport. */
+  .marquee { width: 100%; min-width: 0; align-self: stretch; }
 }
 
 /* ============================================================

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -38,13 +38,13 @@ export default defineConfig({
     },
     {
       name: "chromium",
-      testIgnore: /mobile-(web|auth)\.spec\.ts/,
+      testIgnore: /mobile-.*\.spec\.ts/,
       use: { ...devices["Desktop Chrome"] },
       dependencies: ["setup"]
     },
     {
       name: "mobile-chrome",
-      testMatch: /mobile-(web|auth)\.spec\.ts/,
+      testMatch: /mobile-.*\.spec\.ts/,
       use: {
         // iPhone 14 profile on Chromium (avoids WebKit install; same viewport/UA).
         ...devices["Desktop Chrome"],

--- a/e2e/tests/mobile-landing.spec.ts
+++ b/e2e/tests/mobile-landing.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("landing page mobile (<768px)", () => {
+  test("hero email CTA is centered and the page has no horizontal overflow", async ({ page }) => {
+    await page.goto("/");
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+
+    const heroForm = page.locator(".hero-form").first();
+    await expect(heroForm).toBeVisible();
+
+    const rect = await heroForm.evaluate((el) => el.getBoundingClientRect());
+    const leftGap = rect.left;
+    const rightGap = viewport!.width - rect.right;
+    expect(Math.abs(leftGap - rightGap)).toBeLessThanOrEqual(2);
+
+    // Regression guard: the infinite bank-logo marquee previously inflated
+    // the page width past the viewport, letting mobile browsers zoom out.
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(viewport!.width);
+  });
+
+  test("bank marquee does not overflow the viewport", async ({ page }) => {
+    await page.goto("/");
+
+    const marquee = page.locator(".marquee").first();
+    await marquee.scrollIntoViewIfNeeded();
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+
+    const rect = await marquee.evaluate((el) => el.getBoundingClientRect());
+    expect(rect.right).toBeLessThanOrEqual(viewport!.width + 1);
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(viewport!.width);
+  });
+});


### PR DESCRIPTION
## Summary
- Centers the hero email signup CTA (and its surrounding hero copy) on mobile — it was rendering left-aligned while the rest of the design intends a centered mobile hero.
- Fixes the infinite bank-logo marquee overflowing the viewport on mobile: it's a flex item under a column layout (`align-items: flex-start`), so without an explicit width it was sizing to its unrolled track's full content width instead of the viewport — that extra width is what let mobile browsers pinch/auto-zoom out to reveal blank overflow.

## Root cause
Both reported symptoms traced back to `app/assets/stylesheets/landing.css`:
- `.trust-inner` switches to `flex-direction: column` under 720px, which makes `.marquee`'s cross-axis (width) size to its content instead of stretching to the container — even though `.marquee` already has `overflow: hidden`. Added `width: 100%; min-width: 0; align-self: stretch;` to force it back to viewport-constrained width.
- The hero CTA form had no centering rule for the mobile breakpoint while the rest of the design called for a centered mobile hero — added `text-align: center` / `margin: 0 auto` rules scoped to `@media (max-width: 640px)`.

## Test plan
- [ ] Added `e2e/tests/mobile-landing.spec.ts` asserting the hero CTA is horizontally centered and `document.documentElement.scrollWidth` never exceeds the viewport width on mobile (regression guard for the marquee bug).
- [ ] Broadened the `mobile-chrome` Playwright project's `testMatch` (and the `chromium` project's `testIgnore`) from `mobile-(web|auth)\.spec\.ts` to `mobile-.*\.spec\.ts` so this new file runs under the iPhone 14 viewport project.
- [ ] Couldn't run the full Rails/Playwright stack in this sandbox (no Postgres/bundled gems, no network access to download a Chromium binary) — comment `run-e2e` on this PR to trigger the `Rails E2E` workflow, or pull the branch locally to verify visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DsvoVpXubsgHN59138zPj

---
_Generated by [Claude Code](https://claude.ai/code/session_019DsvoVpXubsgHN59138zPj)_